### PR TITLE
Don't make the example silent for debugging

### DIFF
--- a/hspec.cabal
+++ b/hspec.cabal
@@ -32,7 +32,6 @@ Library
       src
   build-depends:
       base >= 4 && <= 5
-    , silently >= 1.1.1 && < 2
     , ansi-terminal == 0.5.5
     , time < 1.5
     , transformers >= 0.2.0 && < 0.4.0

--- a/src/Test/Hspec/HUnit.hs
+++ b/src/Test/Hspec/HUnit.hs
@@ -24,14 +24,13 @@
 --
 module Test.Hspec.HUnit () where
 
-import           System.IO.Silently
 import           Test.Hspec.Core
 import qualified Test.HUnit as HU
 import           Data.List (intersperse)
 
 instance Example HU.Test where
   evaluateExample _ test = do
-    (counts, fails) <- silence $ HU.runTestText HU.putTextToShowS test
+    (counts, fails) <- HU.runTestText HU.putTextToShowS test
     let r = if HU.errors counts + HU.failures counts == 0
              then Success
              else Fail (details $ fails "")

--- a/src/Test/Hspec/QuickCheck.hs
+++ b/src/Test/Hspec/QuickCheck.hs
@@ -22,7 +22,6 @@ module Test.Hspec.QuickCheck (
 , prop
 ) where
 
-import           System.IO.Silently
 import           Test.Hspec.Core
 import           Test.Hspec.Config (Config(..))
 import qualified Test.QuickCheck as QC
@@ -36,7 +35,7 @@ prop n p = DSL.it n (QC.property p)
 
 instance Example QC.Property where
   evaluateExample c p = do
-    r <- silence $ QC.quickCheckWithResult (configQuickCheckArgs c) p
+    r <- QC.quickCheckWithResult (configQuickCheckArgs c) p
     return $
       case r of
         QC.Success {}               -> Success


### PR DESCRIPTION
Hi,

Sometimes I need to print something to stdout for debugging while testing.
But it's not possible because `silence` is applied for the running example.

For example, this code won't print out "baz" in console.

``` haskell
import Test.Hspec

main :: IO ()
main = hspec $ do
  describe "foo" $ do
    it "bar" $ do
      print "baz" -- This will be ignored
      True `shouldBe` True
```

How about to remove `silence` and make stdout speak again?
