### PR TITLE
Fix Could not find module error when installing with --enable-tests

### DIFF
--- a/hspec.cabal
+++ b/hspec.cabal
@@ -221,6 +221,8 @@ test-suite hspec-discover-integration-test-with-formatter
       hspec-discover/integration-test/with-formatter
   main-is:
       Spec.hs
+  other-modules:
+      FooSpec
   build-depends:
       base    == 4.*
     , hspec
@@ -234,6 +236,9 @@ test-suite hspec-discover-integration-test-with-io-formatter
       hspec-discover/integration-test/with-io-formatter
   main-is:
       Spec.hs
+  other-modules:
+      FooSpec
+      Formatter
   build-depends:
       base    == 4.*
     , hspec


### PR DESCRIPTION
hspec tarball on hackage cannot be installed with `--enable-tests` because of the files missing
