### PR TITLE
Add ability to hook main with hspec-discover

### DIFF
--- a/hspec-discover/integration-test/hspec-discover-integration-tests.cabal
+++ b/hspec-discover/integration-test/hspec-discover-integration-tests.cabal
@@ -62,3 +62,18 @@ test-suite with-formatter-empty
   build-depends:
       base    == 4.*
     , hspec
+
+test-suite with-no-main
+  type:
+      exitcode-stdio-1.0
+  ghc-options:
+      -Wall -Werror
+  hs-source-dirs:
+      with-no-main
+  main-is:
+      Main.hs
+  other-modules:
+      Spec
+  build-depends:
+      base    == 4.*
+    , hspec

--- a/hspec-discover/integration-test/with-no-main/Main.hs
+++ b/hspec-discover/integration-test/with-no-main/Main.hs
@@ -1,0 +1,10 @@
+module Main where
+
+import Test.Hspec
+import Spec
+
+main :: IO ()
+main = do
+  putStrLn "before spec"
+  hspec spec
+  putStrLn "after spec"

--- a/hspec-discover/integration-test/with-no-main/Spec.hs
+++ b/hspec-discover/integration-test/with-no-main/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --no-main #-}

--- a/hspec-discover/src/Config.hs
+++ b/hspec-discover/src/Config.hs
@@ -5,28 +5,38 @@ module Config (
 , usage
 ) where
 
+import           Data.Maybe
 import           System.Console.GetOpt
 
 data Config = Config {
   configNested :: Bool
 , configFormatter :: Maybe String
+, configNoMain :: Bool
 } deriving (Eq, Show)
 
 defaultConfig :: Config
-defaultConfig = Config False Nothing
+defaultConfig = Config False Nothing False
 
 options :: [OptDescr (Config -> Config)]
 options = [
     Option [] ["nested"]    (NoArg  $ \c -> c   {configNested = True}) ""
   , Option [] ["formatter"] (ReqArg (\s c -> c {configFormatter = Just s}) "FORMATTER") ""
+  , Option [] ["no-main"]   (NoArg  $ \c -> c   {configNoMain = True}) ""
   ]
 
 usage :: String -> String
-usage prog = "\nUsage: " ++ prog ++ " SRC CUR DST [--formatter=FORMATTER]\n"
+usage prog = "\nUsage: " ++ prog ++ " SRC CUR DST [--formatter=FORMATTER] [--no-main]\n"
 
 parseConfig :: String -> [String] -> Either String Config
 parseConfig prog args = case getOpt Permute options args of
-    (opts, [], []) -> Right (foldl (flip id) defaultConfig opts)
+    (opts, [], []) -> let
+        c = (foldl (flip id) defaultConfig opts)
+      in
+        if (configNoMain c && isJust (configFormatter c))
+           then
+             formatError "option `--formatter=<fmt>' does not make sense with `--no-main'\n"
+           else
+             Right c
     (_, _, err:_)  -> formatError err
     (_, arg:_, _)  -> formatError ("unexpected argument `" ++ arg ++ "'\n")
   where

--- a/hspec-discover/test/ConfigSpec.hs
+++ b/hspec-discover/test/ConfigSpec.hs
@@ -18,18 +18,28 @@ spec = do
     it "recognizes --formatter" $ do
       parse ["--formatter", "someFormatter"] `shouldBe` Right (defaultConfig {configFormatter = Just "someFormatter"})
 
+    it "recognizes --no-main" $ do
+      parse ["--no-main"] `shouldBe` Right (defaultConfig {configNoMain = True})
+
     it "returns error message on unrecognized option" $ do
       parse ["--foo"] `shouldBe` (Left . unlines) [
           "hspec-discover: unrecognized option `--foo'"
         , ""
-        , "Usage: hspec-discover SRC CUR DST [--formatter=FORMATTER]"
+        , "Usage: hspec-discover SRC CUR DST [--formatter=FORMATTER] [--no-main]"
         ]
 
     it "returns error message on unexpected argument" $ do
       parse ["foo"]   `shouldBe` (Left . unlines) [
           "hspec-discover: unexpected argument `foo'"
         , ""
-        , "Usage: hspec-discover SRC CUR DST [--formatter=FORMATTER]"
+        , "Usage: hspec-discover SRC CUR DST [--formatter=FORMATTER] [--no-main]"
+        ]
+
+    it "returns error message on --formatter=<fmt> with --no-main" $ do
+      parse ["--no-main", "--formatter=foo"] `shouldBe` (Left . unlines) [
+          "hspec-discover: option `--formatter=<fmt>' does not make sense with `--no-main'"
+        , ""
+        , "Usage: hspec-discover SRC CUR DST [--formatter=FORMATTER] [--no-main]"
         ]
 
     context "when option is given multiple times" $ do


### PR DESCRIPTION
This patch adds the --hookMain flag to hspec-discover, when this flag is set
hspec-discover generates a module called "Spec" instead of the usual "Main" and
it renames the "main" function to "hspecMain".

The purpose of this is to have the ability to add custom IO actions before/after
any tests are run instead of before and after each test item as is already
possible with the functions before, after and around.

To use --hookMain one would create a new Main module and import the Spec module
from there and then call hspecMain when appropriate.

To pass the --hookMain flag to hspec-discover when using it as a ghc
pre-processor the following should be put in Spec.hs:

```
{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --hookMain #-}
```
