### PR TITLE
Made `totalCount` pointfree

### DIFF
--- a/src/Test/Hspec/Formatters/Internal.hs
+++ b/src/Test/Hspec/Formatters/Internal.hs
@@ -79,7 +79,7 @@ usedSeed = gets stateUsedSeed
 
 -- | The total number of examples encountered so far.
 totalCount :: FormatterState -> Int
-totalCount s = successCount s + pendingCount s + failCount s
+totalCount = sum . sequence [successCount, pendingCount, failCount]
 
 -- NOTE: We use an IORef here, so that the state persists when UserInterrupt is
 -- thrown.


### PR DESCRIPTION
Uses `sequence` to inject the FormatterState into each of the functions in the list, then sums them up with `sum`. 
