### PR TITLE
[RFC] Sessions using unsafePerformIO

### DIFF
--- a/hspec.cabal
+++ b/hspec.cabal
@@ -46,6 +46,7 @@ Library
     , time
     , transformers  >= 0.2.2.0 && < 0.4.0
     , deepseq
+    , monad-control >= 0.3
     , HUnit         >= 1.2.5
     , QuickCheck    >= 2.5.1
     , quickcheck-io


### PR DESCRIPTION
Here is the other RFC for sessions as compared to Pull #154.  It does not make any internal changes to hspec and instead uses unsafePerformIO.  Also I called these sessions since they are not quite scenarios (which I guess is the usual BDD term), but they can of course be rephrased.

I implemented it as two commits: the first one implements sessions with manual state passing using no extra dependencies and the follow-on commit uses monad-control to thread the state of a monad through the tests.

Both this and #154 try and implement the same thing in different ways and are both still RFCs.  No rush though, I saw you are on vacation and I am not in a hurry.  The design will probably still have to evolve depending on your feedback.
