### PR TITLE
Add a link to guard-haskell gem to Other resources

### DIFF
--- a/doc/index.markdown
+++ b/doc/index.markdown
@@ -37,6 +37,7 @@ An example is worth a thousand words, so here we go:
 * [API documentation](http://hackage.haskell.org/packages/archive/hspec/latest/doc/html/Test-Hspec.html)
 * [SmallCheck integration](http://hackage.haskell.org/package/hspec-smallcheck)
 * [Vim syntax file for Hspec](https://github.com/hspec/hspec.vim#readme)
+* [Guard plugin for Hspec](http://rubygems.org/gems/guard-haskell)
 * [A report of Hspec's behavior](report.html)
 
 ## Support


### PR DESCRIPTION
As suggested in #hspec
