### PR TITLE
add beforeWith to transform param for cases

### DIFF
--- a/src/Test/Hspec.hs
+++ b/src/Test/Hspec.hs
@@ -24,6 +24,7 @@ module Test.Hspec (
 , pending
 , pendingWith
 , before
+, beforeWith
 , after
 , after_
 , around
@@ -87,6 +88,10 @@ parallel = mapSpecItem $ \item -> item {itemIsParallelizable = True}
 -- | Run a custom action before every spec item.
 before :: IO a -> SpecWith a -> Spec
 before action = around (action >>=)
+
+-- | Run a custom action before every spec item.
+beforeWith :: (b -> IO a) -> SpecWith a -> SpecWith b
+beforeWith action = aroundWith $ \e x -> action x >>= e
 
 -- | Run a custom action after every spec item.
 after :: ActionWith a -> SpecWith a -> SpecWith a

--- a/test/Test/HspecSpec.hs
+++ b/test/Test/HspecSpec.hs
@@ -129,6 +129,14 @@ spec = do
           H.it "foo" $ property $ append "foo"
         readIORef ref `shouldReturn` (take 200 . cycle) ["before", "foo"]
 
+  describe "beforeWith" $ do
+    it "runs an action before every spec item" $ do
+      let action :: Int -> IO String
+          action n = return (show n)
+      property $ \n -> do
+        silence $ H.hspec $ H.before (return n) $ H.beforeWith action $ do
+          H.it "foo" $ (`shouldBe` show n)
+
   describe "after" $ do
     it "must be used with a before action" $ do
       ref <- newIORef ([] :: [String])


### PR DESCRIPTION
Hspec2 now has `aroundWith`. However, sometimes, `beforeWith` can be more convenient.

Related to issue #161.
