### PR TITLE
Use enclosed-exceptions to implement safeTry

### DIFF
--- a/hspec.cabal
+++ b/hspec.cabal
@@ -53,6 +53,7 @@ Library
     , QuickCheck    >= 2.5.1
     , quickcheck-io
     , hspec-expectations == 0.5.0.*
+    , enclosed-exceptions
   exposed-modules:
       Test.Hspec
       Test.Hspec.Core
@@ -111,6 +112,7 @@ test-suite spec
     , QuickCheck
     , quickcheck-io
     , hspec-expectations
+    , enclosed-exceptions
 
     , hspec-meta >= 1.9.1
     , process

--- a/src/Test/Hspec/Util.hs
+++ b/src/Test/Hspec/Util.hs
@@ -11,8 +11,8 @@ module Test.Hspec.Util (
 
 import           Data.List
 import           Data.Char (isSpace)
-import           Control.Applicative
 import qualified Control.Exception as E
+import           Control.Exception.Enclosed (tryAny)
 
 import           Test.Hspec.Compat (showType)
 
@@ -44,15 +44,7 @@ formatException :: E.SomeException -> String
 formatException (E.SomeException e) = showType e ++ " (" ++ show e ++ ")"
 
 safeTry :: IO a -> IO (Either E.SomeException a)
-safeTry action = (Right <$> (action >>= E.evaluate)) `E.catches` [
-  -- Re-throw AsyncException, otherwise execution will not terminate on SIGINT
-  -- (ctrl-c).  All AsyncExceptions are re-thrown (not just UserInterrupt)
-  -- because all of them indicate severe conditions and should not occur during
-  -- normal operation.
-    E.Handler $ \e -> E.throwIO (e :: E.AsyncException)
-
-  , E.Handler $ \e -> (return . Left) (e :: E.SomeException)
-  ]
+safeTry = tryAny
 
 -- |
 -- A tuple that represents the location of an example within a spec.


### PR DESCRIPTION
I haven't been able to get a reliable reproducing case yet, but we had
some code where some failing test cases ended up bringing down the
entire test process. I can't be 100% that this solves the problem, but
I've run the test suite multiple times with this change, and everything
seems correct.

This seems to have come from the fact that we're using the async
library, and the race function in particular, to have multiple
concurrent actions running in our tests. (I can provide more details if
relevant.) async was using AsyncException to kill threads, which was
somehow propagating too far.
