### PR TITLE
Add hspec task in Makefile

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -15,11 +15,17 @@ less:
 watch-less: less
 	watchr -e 'watch("(^js/.*\.js)|(^css/.*\.less)") {system "make less"};'
 
-setup: pygments
+setup: pygments hspec
 	bundle install
 
 pygments:
 	git clone https://github.com/sol/pygments -b hspec-doc
+
+hspec:
+	cd .. && \
+		cabal sandbox init && \
+		cabal install --only-dependencies && \
+		cabal build
 
 clean:
 	-rm -r _site


### PR DESCRIPTION
Previously, trying to build the site caused errors because ../dist
didn't exist. This commit fixes the issue by adding a 'hspec' task which
creates a sandbox and builds Hspec.
