### PR TITLE
Add retryWith

### DIFF
--- a/example/Spec.hs
+++ b/example/Spec.hs
@@ -2,6 +2,7 @@ module Main (main, spec) where
 
 import Test.Hspec
 import Test.QuickCheck
+import Data.IORef
 
 main :: IO ()
 main = hspec spec
@@ -14,3 +15,14 @@ spec = do
 
     it "gives the original list, if applied twice" $ property $
       \xs -> (reverse . reverse) xs == (xs :: [Int])
+
+  describe "retry test" $ do
+    ref <- runIO $ newIORef (0::Int)
+    it "retry" $ do
+      let incr :: IO Int
+          incr = do
+            val <- readIORef ref
+            writeIORef ref (val+1)
+            return val
+      retryWith 11 $ do
+        incr `shouldReturn` (10::Int)

--- a/hspec-core/src/Test/Hspec.hs
+++ b/hspec-core/src/Test/Hspec.hs
@@ -29,6 +29,7 @@ module Test.Hspec (
 , around
 , parallel
 , runIO
+, retryWith
 
 -- * Running a spec
 , hspec

--- a/hspec-core/src/Test/Hspec/Core.hs
+++ b/hspec-core/src/Test/Hspec/Core.hs
@@ -27,6 +27,7 @@ module Test.Hspec.Core (
 , modifyParams
 , describe
 , it
+, retryWith
 ) where
 
 import           Test.Hspec.Core.Type

--- a/hspec.cabal
+++ b/hspec.cabal
@@ -66,4 +66,5 @@ test-suite example
       base == 4.*
     , hspec
     , QuickCheck
+    , random
   default-language: Haskell2010


### PR DESCRIPTION
Add retryWith-function.
(Our test partially fails sometime by the system's condition. so I add this.)

When test is failed, this function retry the test until the count = 1.
This function's test is in "hspec / example / Spec.hs".

I want to write the test on "test/Test/Hspec/Core/TypeSpec.hs",
But the code causes following compilation error.
I do not know why Spec.hs is ok and TypeSpec.hs is not good.
I can not find the solution.

```
test/Test/Hspec/Core/TypeSpec.hs:140:7:
    No instance for (Example (Test.Hspec.Core.Type.Retry Expectation))
      arising from a use of ‘it’
    In the expression: it "retry"
    In a stmt of a 'do' block:
      it "retry"
      $ do { let incr :: IO Int
                 incr = ...;
             H.retryWith 11 $ do { incr `shouldReturn` (10 :: Int) } }
    In the second argument of ‘($)’, namely
      ‘do { ref <- runIO $ newIORef (0 :: Int);
            it "retry"
            $ do { let ...;
                   H.retryWith 11 $ do { ... } } }’
```
