### PR TITLE
format source location messages to look like gcc messages

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,6 @@
+## Changes in 2.1.3
+  - Format source locations like gcc does
+
 ## Changes in 2.1.2
   - Re-export `before_` from `Test.Hspec`
 

--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -1,5 +1,5 @@
 name:             hspec-core
-version:          2.1.2
+version:          2.1.3
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2011-2014 Simon Hengel,

--- a/hspec-core/src/Test/Hspec/Core/Formatters.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters.hs
@@ -181,17 +181,16 @@ defaultFailedFormatter = do
 
     formatFailure :: (Int, FailureRecord) -> FormatM ()
     formatFailure (n, FailureRecord mLoc path reason) = do
+      forM_ mLoc $ \loc -> do
+        withInfoColor $ writeLine (formatLoc loc)
       write ("  " ++ show n ++ ") ")
       writeLine (formatRequirement path)
       withFailColor $ do
         forM_ (lines err) $ \x -> do
           writeLine ("       " ++ x)
-      forM_ mLoc $ \loc -> do
-        writeLine ""
-        withInfoColor $ writeLine (formatLoc loc)
       where
         err = either (("uncaught exception: " ++) . formatException) id reason
-        formatLoc (Location file line _column accuracy) = "     # " ++ file ++ ":" ++ show line ++ bestEffortMarking
+        formatLoc (Location file line _column accuracy) = "  " ++ file ++ ":" ++ show line ++ ":" ++ bestEffortMarking
           where
             bestEffortMarking = case accuracy of
               ExactLocation -> ""

--- a/hspec-core/test/Test/Hspec/Core/FormattersSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/FormattersSpec.hs
@@ -162,13 +162,20 @@ failed_examplesSpec formatter = do
     context "when a failed example has a source location" $ do
       let bestEffortExplanation = "Source locations marked with \"best-effort\" are calculated heuristically and may be incorrect."
 
+      it "includes the source locations above the error messages" $ do
+        let loc = H.Location "test/FooSpec.hs" 23 0 H.ExactLocation
+            addLoc e = e {H.itemLocation = Just loc}
+        r <- runSpec $ H.mapSpecItem_ addLoc $ do
+          H.it "foo" False
+        r `shouldContain` ["  test/FooSpec.hs:23:", "  1) foo"]
+
       context "when source location is exact" $ do
         it "includes that source locations" $ do
           let loc = H.Location "test/FooSpec.hs" 23 0 H.ExactLocation
               addLoc e = e {H.itemLocation = Just loc}
           r <- runSpec $ H.mapSpecItem_ addLoc $ do
             H.it "foo" False
-          r `shouldSatisfy` any (== "     # test/FooSpec.hs:23")
+          r `shouldSatisfy` any (== "  test/FooSpec.hs:23:")
 
         it "does not include 'best-effort' explanation" $ do
           let loc = H.Location "test/FooSpec.hs" 23 0 H.ExactLocation
@@ -183,7 +190,7 @@ failed_examplesSpec formatter = do
               addLoc e = e {H.itemLocation = Just loc}
           r <- runSpec $ H.mapSpecItem_ addLoc $ do
             H.it "foo" False
-          r `shouldSatisfy` any (== "     # test/FooSpec.hs:23 (best-effort)")
+          r `shouldSatisfy` any (== "  test/FooSpec.hs:23: (best-effort)")
 
         it "includes 'best-effort' explanation" $ do
           let loc = H.Location "test/FooSpec.hs" 23 0 H.BestEffort

--- a/hspec-discover/hspec-discover.cabal
+++ b/hspec-discover/hspec-discover.cabal
@@ -1,5 +1,5 @@
 name:             hspec-discover
-version:          2.1.2
+version:          2.1.3
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2012-2014 Simon Hengel

--- a/hspec.cabal
+++ b/hspec.cabal
@@ -1,5 +1,5 @@
 name:             hspec
-version:          2.1.2
+version:          2.1.3
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2011-2014 Simon Hengel,
@@ -41,8 +41,8 @@ library
       src
   build-depends:
       base == 4.*
-    , hspec-core == 2.1.2
-    , hspec-discover == 2.1.2
+    , hspec-core == 2.1.3
+    , hspec-discover == 2.1.3
     , hspec-expectations == 0.6.1.*
     , transformers >= 0.2.2.0
     , QuickCheck >= 2.5.1


### PR DESCRIPTION
Lots of tools (e.g. vim's quickfix) know how to parse gcc messages (and
allow you to jump to source locations).

See below for how the messages in this branch look like. I'm not overly passionate about the exact message format, but this seems to be the most logical to me and it works with vim's quickfix and geany.

```
Dev
  something
    foo FAILED [1]
    bar
      baz FAILED [2]
      boo FAILED [3]

Failures:

  dev/DevSpec.hs:15: (best-effort)
  1) Dev.something foo
       expected: False
        but got: True

  dev/DevSpec.hs:18: (best-effort)
  2) Dev.something.bar baz

  dev/DevSpec.hs:20: (best-effort)
  3) Dev.something.bar boo

Source locations marked with "best-effort" are calculated heuristically and may be incorrect.

Randomized with seed 1677688156
```