### PR TITLE
Add rollbackWith for use together with retryWith

### DIFF
--- a/hspec-contrib/src/Test/Hspec/Contrib/Retry.hs
+++ b/hspec-contrib/src/Test/Hspec/Contrib/Retry.hs
@@ -1,11 +1,15 @@
 {-# LANGUAGE TypeFamilies #-}
 -- |
 -- maintainer: Junji Hashimoto <junji.hashimoto@gree.net>
-module Test.Hspec.Contrib.Retry (retryWith) where
+module Test.Hspec.Contrib.Retry (
+  retryWith
+, rollbackWith
+) where
 
 import           Test.Hspec.Core.Spec
 
 data Retry a = Retry Int a
+data Rollback a = Rollback a a
 
 instance Example a => Example (Retry a) where
   type Arg (Retry a) = Arg a
@@ -16,6 +20,16 @@ instance Example a => Example (Retry a) where
       _ | n > 1 -> evaluateExample (Retry (pred n) example) a b c
       _ -> return v
 
+instance Example a => Example (Rollback a) where
+  type Arg (Rollback a) = Arg a
+  evaluateExample (Rollback rollback example) a b c = do
+    v <- evaluateExample example a b c
+    case v of
+      Success -> return v
+      _ -> do
+        _ <- evaluateExample rollback a b c
+        return v
+
 -- | Retry evaluating example that may be failed until success.
 retryWith :: Int
           -- ^ number of retries, when this number is 1, just evaluate example and finish.
@@ -24,3 +38,16 @@ retryWith :: Int
           -> Retry a
           -- ^ Retry is instance of Example.
 retryWith = Retry
+
+-- | Rollback evaluating first example(for rollback) and second example (for test)
+--
+-- When second example (for test) is failed, first example is used for rollback.
+--
+-- When second example (for test) is passed, first example is not used.
+rollbackWith :: a
+             -- ^ example for rollback
+             -> a
+             -- ^ example for test
+             -> Rollback a
+             -- ^ Rollback is instance of Example.
+rollbackWith = Rollback

--- a/hspec-contrib/test/Test/Hspec/Contrib/RetrySpec.hs
+++ b/hspec-contrib/test/Test/Hspec/Contrib/RetrySpec.hs
@@ -20,3 +20,23 @@ spec = do
             return val
       retryWith 11 $ do
         incr `shouldReturn` (10::Int)
+  describe "rollback test" $ do
+    ref <- runIO $ newIORef (0::Int)
+    total <- runIO $ newIORef (0::Int)
+    let incr :: IO Int
+        incr = do
+          val <- readIORef ref
+          writeIORef ref (val+2)
+          modifyIORef total (+1)
+          return val
+        decr :: IO ()
+        decr = do
+          val <- readIORef ref
+          writeIORef ref (val-1)
+          return ()
+    it "retry with rollback" $ do
+      retryWith 4 $
+        rollbackWith decr $ -- "decr" is example for rollback.
+          incr `shouldReturn` (3::Int)
+    it "check total counts of retry" $ do
+      readIORef total `shouldReturn` 4


### PR DESCRIPTION
Add rollbackWith for use together with retryWith.
When example(second argument) is failed, rollback(first argument) is used.
(When example is passed, rollback is not used.)
