### PR TITLE
hspec-discover: Refactor slightly and add a help message

### DIFF
--- a/hspec-discover/src/Config.hs
+++ b/hspec-discover/src/Config.hs
@@ -1,6 +1,7 @@
 module Config (
   Config (..)
 , defaultConfig
+, helpMessage
 , parseConfig
 , usage
 ) where
@@ -13,10 +14,11 @@ data Config = Config {
 , configFormatter :: Maybe String
 , configNoMain :: Bool
 , configModuleName :: Maybe String
+, configHelp :: Bool
 } deriving (Eq, Show)
 
 defaultConfig :: Config
-defaultConfig = Config False Nothing False Nothing
+defaultConfig = Config False Nothing False Nothing False
 
 options :: [OptDescr (Config -> Config)]
 options = [
@@ -24,22 +26,25 @@ options = [
   , Option [] ["formatter"] (ReqArg (\s c -> c {configFormatter = Just s}) "FORMATTER") ""
   , Option [] ["module-name"] (ReqArg (\s c -> c {configModuleName = Just s}) "NAME") ""
   , Option [] ["no-main"] (NoArg $ \c   -> c {configNoMain = True}) ""
+  , Option [] ["help"] (NoArg $ \c -> c {configHelp = True}) ""
   ]
 
 usage :: String -> String
-usage prog = "\nUsage: " ++ prog ++ " SRC CUR DST [--module-name=NAME]\n"
+usage prog = "Usage: " ++ prog ++ " SRC CUR DST [--module-name=NAME]"
 
 parseConfig :: String -> [String] -> Either String Config
 parseConfig prog args = case getOpt Permute options args of
     (opts, [], []) -> let
-        c = (foldl (flip id) defaultConfig opts)
-      in
-        if (configNoMain c && isJust (configFormatter c))
-           then
-             formatError "option `--formatter=<fmt>' does not make sense with `--no-main'\n"
-           else
-             Right c
+        c = foldl (flip id) defaultConfig opts
+      in validateConfig c
     (_, _, err:_)  -> formatError err
     (_, arg:_, _)  -> formatError ("unexpected argument `" ++ arg ++ "'\n")
   where
-    formatError err = Left (prog ++ ": " ++ err ++ usage prog)
+    formatError err = Left (prog ++ ": " ++ err ++ "\n" ++ usage prog ++ "\n")
+
+    validateConfig c | configNoMain c && isJust (configFormatter c) =
+        formatError "option `--formatter=<fmt>' does not make sense with `--no-main'\n"
+    validateConfig c = Right c
+
+helpMessage :: String -> String
+helpMessage prog = usageInfo (usage prog) options

--- a/hspec-discover/src/Run.hs
+++ b/hspec-discover/src/Run.hs
@@ -67,12 +67,10 @@ mkSpecModule src conf nodes =
   . formatSpecs nodes
   ) "\n"
   where
-    driver =
-        case configNoMain conf of
-          False ->
-              showString "main :: IO ()\n"
-            . showString "main = hspec spec\n"
-          True -> ""
+    driver = if configNoMain conf
+             then ""
+             else showString "main :: IO ()\n"
+                . showString "main = hspec spec\n"
 
 moduleName :: FilePath -> Config -> String
 moduleName src conf = fromMaybe (if configNoMain conf then pathToModule src else "Main") (configModuleName conf)

--- a/hspec-discover/src/Run.hs
+++ b/hspec-discover/src/Run.hs
@@ -41,16 +41,18 @@ run args_ = do
   name <- getProgName
   case args_ of
     src : _ : dst : args -> case parseConfig name args of
-      Left err -> do
-        hPutStrLn stderr err
-        exitFailure
+      Left err -> exitError err
+      Right conf | configHelp conf -> putStrLn (helpMessage name)
       Right conf -> do
         when (configNested conf) (hPutStrLn stderr "hspec-discover: WARNING - The `--nested' flag is deprecated and will be removed in a future release!")
         specs <- findSpecs src
         writeFile dst (mkSpecModule src conf specs)
-    _ -> do
-      hPutStrLn stderr (usage name)
-      exitFailure
+    ["help"] -> putStrLn (helpMessage name)
+    _ -> exitError $ "\n" ++ usage name ++ "\nTry `hspec-discover --help` for more information."
+  where
+    exitError err = do
+        hPutStrLn stderr err
+        exitFailure
 
 mkSpecModule :: FilePath -> Config -> [Spec] -> String
 mkSpecModule src conf nodes =


### PR DESCRIPTION
This adds support for filtering the `spec` file paths using a regular
expression, through the `--regex` and `--not-regex` flags.

It's useful for (for example) dealing with temporary files from Emacs'
`flycheck-mode`, which can cause `hspec-discover` to trigger the
compilation of invalid modules (the temporary files themselves).

It also adds a help flag/message and refactors a couple of small parts
on the way.

**UPDATE 09/02/2015**
Okay; so the invalid module name rejection part was moved to #222. This now only contains the refactoring and help message addition.