### PR TITLE
hspec-discover: Reject invalid module names

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,7 @@
+## Changes in 2.1.4
+  - Make `hspec-discover` ignore modules with invalid module names, this fixes
+    issues with `flycheck`'s temporary files
+
 ## Changes in 2.1.3
   - Format source locations like gcc does
 

--- a/README.markdown
+++ b/README.markdown
@@ -65,3 +65,4 @@ To run the test suite do:
  * Junji Hashimoto
  * Jan Matějka
  * Ömer Sinan Ağacan
+ * Pedro Tacla Yamada

--- a/hspec-discover/src/Run.hs
+++ b/hspec-discover/src/Run.hs
@@ -121,12 +121,21 @@ findSpecs src = do
 fileToSpec :: FilePath -> FilePath -> Maybe Spec
 fileToSpec dir file = case reverse $ splitDirectories file of
   x:xs -> case stripSuffix "Spec.hs" x <|> stripSuffix "Spec.lhs" x of
-    Just name | (not . null) name -> Just . Spec (dir </> file) $ (intercalate "." . reverse) (name : xs)
+    Just name | isValidModuleName name && all isValidModuleName xs ->
+      Just . Spec (dir </> file) $ (intercalate "." . reverse) (name : xs)
     _ -> Nothing
   _ -> Nothing
   where
     stripSuffix :: Eq a => [a] -> [a] -> Maybe [a]
     stripSuffix suffix str = reverse <$> stripPrefix (reverse suffix) (reverse str)
+
+-- See `Cabal.Distribution.ModuleName` (http://git.io/bj34)
+isValidModuleName :: String -> Bool
+isValidModuleName [] = False
+isValidModuleName (c:cs) = isUpper c && all isValidModuleChar cs
+
+isValidModuleChar :: Char -> Bool
+isValidModuleChar c = isAlphaNum c || c == '_' || c == '\''
 
 getFilesRecursive :: FilePath -> IO [FilePath]
 getFilesRecursive baseDir = sort <$> go []

--- a/hspec-discover/test/RunSpec.hs
+++ b/hspec-discover/test/RunSpec.hs
@@ -84,6 +84,14 @@ spec = do
     it "returns Nothing for invalid spec name" $ do
       fileToSpec "" "foo" `shouldBe` Nothing
 
+    context "when spec does not have a valid module name" $ do
+      it "returns Nothing" $ do
+        fileToSpec "" "flycheck_Spec.hs" `shouldBe` Nothing
+
+    context "when any component of a hierarchical module name is not valid"$ do
+      it "returns Nothing" $ do
+        fileToSpec "" ("Valid" </> "invalid"  </>"MiddleNamesSpec.hs") `shouldBe` Nothing
+
     context "when path has directory component" $ do
       it "converts path to spec name" $ do
         let file = "Foo" </> "Bar" </> "BazSpec.hs"


### PR DESCRIPTION
Tweaks `fileToSpec` so that it rejects files with invalid module names,
as discussed in #221. Please let me know if you'd like me to test or
change anything. I know I shouldn't have refactored the function as well
as adding this feature, but I thought it looked a little clearer like
this.

Let me know what you think.