### PR TITLE
Compatibility with QuickCheck 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: haskell
 
 env:
   - QC=QuickCheck
+  - QC=QuickCheck-2.7
   - QC=QuickCheck-2.6
   - QC=QuickCheck-2.5.1.1
   - QC=QuickCheck-2.5.1

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,6 @@
+## Changes in 2.1.5
+  - Compatibility with QuickCheck-2.8
+
 ## Changes in 2.1.4
   - Make `hspec-discover` ignore modules with invalid module names, this fixes
     issues with `flycheck`'s temporary files

--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -1,5 +1,5 @@
 name:             hspec-core
-version:          2.1.4
+version:          2.1.5
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2011-2014 Simon Hengel,

--- a/hspec-core/src/Test/Hspec/Core/Example.hs
+++ b/hspec-core/src/Test/Hspec/Core/Example.hs
@@ -88,6 +88,9 @@ instance Example (a -> QC.Property) where
         QC.Failure {QC.output = m}  -> fromMaybe (Fail $ sanitizeFailureMessage r) (parsePending m)
         QC.GaveUp {QC.numTests = n} -> Fail ("Gave up after " ++ pluralize n "test" )
         QC.NoExpectedFailure {}     -> Fail ("No expected failure")
+#if MIN_VERSION_QuickCheck(2,8,0)
+        QC.InsufficientCoverage {}  -> Fail ("Insufficient coverage")
+#endif
     where
       qcProgressCallback = QCP.PostTest QCP.NotCounterexample $
         \st _ -> progressCallback (QC.numSuccessTests st, QC.maxSuccessTests st)

--- a/hspec-discover/hspec-discover.cabal
+++ b/hspec-discover/hspec-discover.cabal
@@ -1,5 +1,5 @@
 name:             hspec-discover
-version:          2.1.4
+version:          2.1.5
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2012-2014 Simon Hengel

--- a/hspec.cabal
+++ b/hspec.cabal
@@ -1,5 +1,5 @@
 name:             hspec
-version:          2.1.4
+version:          2.1.5
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2011-2014 Simon Hengel,
@@ -41,8 +41,8 @@ library
       src
   build-depends:
       base == 4.*
-    , hspec-core == 2.1.4
-    , hspec-discover == 2.1.4
+    , hspec-core == 2.1.5
+    , hspec-discover == 2.1.5
     , hspec-expectations == 0.6.1.*
     , transformers >= 0.2.2.0
     , QuickCheck >= 2.5.1


### PR DESCRIPTION
This fixes a warning about non-exhaustive pattern-matches.

@sol: Please review, if you can.