### PR TITLE
Add -j/--jobs and --unlimited-jobs to allow users to limit parallelism

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -61,6 +61,7 @@ To run the test suite do:
  * Raine Virta
  * Ron Watkins
  * Ryan Mulligan
+ * Ryan Trinkle
  * Simon Hengel
  * Sönke Hahn
  * Takayuki Muranushi

--- a/doc/parallel-spec-execution.md
+++ b/doc/parallel-spec-execution.md
@@ -45,4 +45,7 @@ All specs that are not explicitly marked with `parallel` are run in the
 application's main thread.
 
 
-By default, the number of threads available for parallel execution is equal to the number of processors available to the process, as determined by `+RTS -N<n>`.  A different number (higher or lower) can be specified using the `-j` flag.  Note that this number is in addition to the main thread, and must be at least 1 (otherwise, parallelizable jobs would not be able to run).
+By default, the number of threads available for parallel execution is equal to
+the number of processors available to the process, as determined by
+`+RTS -N<n>`.  A different number (higher or lower) can be specified using the
+`-j` flag.  Note that this number is in addition to the main thread.

--- a/doc/parallel-spec-execution.md
+++ b/doc/parallel-spec-execution.md
@@ -43,3 +43,6 @@ Link the program with `-threaded` and pass `+RTS -N -RTS` when running it:
 
 All specs that are not explicitly marked with `parallel` are run in the
 application's main thread.
+
+
+By default, the number of threads available for parallel execution is equal to the number of processors available to the process, as determined by `+RTS -N<n>`.  A different number (higher or lower) can be specified using the `-j` flag.  Note that this number is in addition to the main thread, and must be at least 1 (otherwise, parallelizable jobs would not be able to run).

--- a/hspec-core/src/Test/Hspec/Core/Runner.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner.hs
@@ -123,9 +123,9 @@ hspecWithResult conf spec = do
         seed = (fromJust . configQuickCheckSeed) c
         qcArgs = configQuickCheckArgs c
 
-    jobsSem <- case configMaxParallelJobs c of
-      Nothing -> return Nothing
-      Just maxJobs -> liftM Just $ newQSem maxJobs
+    jobsSem <- newQSem =<< case configMaxParallelJobs c of
+      Nothing -> getNumCapabilities
+      Just maxJobs -> return maxJobs
 
     useColor <- doesUseColor h c
 

--- a/hspec-core/src/Test/Hspec/Core/Runner/Eval.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner/Eval.hs
@@ -22,7 +22,7 @@ import           Test.Hspec.Timer
 type EvalTree = Tree (ActionWith ()) (String, Maybe Location, ProgressCallback -> FormatResult -> IO (FormatM ()))
 
 -- | Evaluate all examples of a given spec and produce a report.
-runFormatter :: Maybe QSem -> Bool -> Handle -> Config -> Formatter -> [SpecTree ()] -> FormatM ()
+runFormatter :: QSem -> Bool -> Handle -> Config -> Formatter -> [SpecTree ()] -> FormatM ()
 runFormatter jobsSem useColor h c formatter specs = do
   headerFormatter formatter
   chan <- liftIO newChan
@@ -53,27 +53,22 @@ every seconds action = do
 
 type FormatResult = Either E.SomeException Result -> FormatM ()
 
-parallelize :: Maybe QSem -> Bool -> (ProgressCallback -> IO Result) -> ProgressCallback -> FormatResult -> IO (FormatM ())
+parallelize :: QSem -> Bool -> (ProgressCallback -> IO Result) -> ProgressCallback -> FormatResult -> IO (FormatM ())
 parallelize jobsSem isParallelizable e
   | isParallelizable = runParallel jobsSem e
-  | otherwise = runSequentially jobsSem e
+  | otherwise = runSequentially e
 
-limitParallelism :: Maybe QSem -> IO a -> IO a
-limitParallelism jobsSem = case jobsSem of
-  Nothing -> id
-  Just s -> E.bracket_ (waitQSem s) (signalQSem s)
-
-runSequentially :: Maybe QSem -> (ProgressCallback -> IO Result) -> ProgressCallback -> FormatResult -> IO (FormatM ())
-runSequentially jobsSem e reportProgress formatResult = return $ do
-  result <- liftIO $ limitParallelism jobsSem $ evalExample (e reportProgress)
+runSequentially :: (ProgressCallback -> IO Result) -> ProgressCallback -> FormatResult -> IO (FormatM ())
+runSequentially e reportProgress formatResult = return $ do
+  result <- liftIO $ evalExample (e reportProgress)
   formatResult result
 
 data Report = ReportProgress Progress | ReportResult (Either E.SomeException Result)
 
-runParallel :: Maybe QSem -> (ProgressCallback -> IO Result) -> ProgressCallback -> FormatResult -> IO (FormatM ())
+runParallel :: QSem -> (ProgressCallback -> IO Result) -> ProgressCallback -> FormatResult -> IO (FormatM ())
 runParallel jobsSem e reportProgress formatResult = do
   mvar <- newEmptyMVar
-  _ <- forkIO $ limitParallelism jobsSem $ do
+  _ <- forkIO $ E.bracket_ (waitQSem jobsSem) (signalQSem jobsSem) $ do
     let progressCallback = replaceMVar mvar . ReportProgress
     result <- evalExample (e progressCallback)
     replaceMVar mvar (ReportResult result)

--- a/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
@@ -430,7 +430,7 @@ spec = do
       let n = 10
           t = 0.01
           dt = t * (fromIntegral n / 2)
-      r <- timeout dt . silence . H.hspecResult . H.parallel $ do
+      r <- timeout dt . silence . withArgs ["-j", show n] . H.hspecResult . H.parallel $ do
         replicateM_ n (H.it "foo" $ sleep t)
       r `shouldBe` Just (H.Summary n 0)
 


### PR DESCRIPTION
For some jobs, particularly when running in an environment like travis-ci, running a huge number of parallel tests can cause memory exhaustion and/or poor performance.  This patch allows hspec to be invoked with a -j or --jobs option to limit this parallelism.  The current default behavior, allowing unlimited jobs in parallel, remains the default.  An --unlimited-jobs switch to explicitly invoke the default behavior is also included for completeness.
