### PR TITLE
workaround for ghcjs

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,5 +1,6 @@
 ## Changes in 2.2.1
   - Make sure that Vim's default `errorformat` recognizes exact locations
+  - GHCJS compatibility
 
 ## Changes in 2.2.0
   - Add source locations to test `Result`


### PR DESCRIPTION
This is a workaround for https://github.com/ghcjs/ghcjs/issues/263

The test-suite of `hspec` currently doesn't run with `ghcjs` because the functions from `silently` also don't work with `ghcjs`. However I have been able to successfully run other `hspec` test-suites compiled with `ghcjs` with this branch.

Once `silently` works with `ghcjs` the tests for `FailureReport` have to be omitted with that compiler. I didn't want to include any `CPP` code for that yet, because the test-suite doesn't run anyways.

@sol: Are you still fine with merging this, pending travis?

(cc: @luite)

