### PR TITLE
Reading command line configuration options from files

### DIFF
--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -42,6 +42,8 @@ library
     , quickcheck-io
     , hspec-expectations == 0.7.2.*
     , async >= 2
+    , directory
+    , filepath
   exposed-modules:
       Test.Hspec.Core.Spec
       Test.Hspec.Core.Hooks
@@ -70,6 +72,7 @@ test-suite spec
       test
     , src
   ghc-options: -Wall
+  cpp-options: -DTEST
   build-depends:
       base >= 4.3 && < 5
     , random
@@ -84,6 +87,8 @@ test-suite spec
     , quickcheck-io
     , hspec-expectations == 0.7.2.*
     , async >= 2
+    , directory
+    , filepath
     , hspec-meta >= 2.2.0
     , silently >= 1.2.4
     , process

--- a/hspec-core/package.yaml
+++ b/hspec-core/package.yaml
@@ -31,6 +31,8 @@ dependencies:
   - quickcheck-io
   - hspec-expectations == 0.7.2.*
   - async >= 2
+  - directory
+  - filepath
 
 library:
   source-dirs: src
@@ -44,6 +46,7 @@ library:
 
 tests:
   spec:
+    cpp-options: -DTEST
     main: Spec.hs
     source-dirs:
       - test

--- a/hspec-core/src/Test/Hspec/Config.hs
+++ b/hspec-core/src/Test/Hspec/Config.hs
@@ -68,9 +68,9 @@ configQuickCheckArgs c = qcArgs
     setSeed :: Integer -> QC.Args -> QC.Args
     setSeed n args = args {QC.replay = Just (mkGen (fromIntegral n), 0)}
 
-getConfig :: Config -> String -> [String] -> IO Config
-getConfig opts_ prog args = do
-  case parseOptions opts_ prog args of
+getConfig :: String -> Config -> (String, [String]) -> IO Config
+getConfig prog opts_ (source, args) = do
+  case parseOptions opts_ prog source args of
     Left (err, msg) -> exitWithMessage err msg
     Right opts -> do
       r <- if configRerun opts then readFailureReport else return Nothing

--- a/hspec-core/src/Test/Hspec/Options.hs
+++ b/hspec-core/src/Test/Hspec/Options.hs
@@ -186,13 +186,13 @@ undocumentedOptions = [
     setHtml :: Result -> Result
     setHtml x = x >>= \c -> return c {configHtmlOutput = True}
 
-parseOptions :: Config -> String -> [String] -> Either (ExitCode, String) Config
-parseOptions c prog args = case getOpt Permute (options ++ undocumentedOptions) args of
+parseOptions :: Config -> String -> String -> [String] -> Either (ExitCode, String) Config
+parseOptions c prog source args = case getOpt Permute (options ++ undocumentedOptions) args of
     (opts, [], []) -> case foldl' (flip id) (Right c) opts of
         Left Help                         -> Left (ExitSuccess, usageInfo ("Usage: " ++ prog ++ " [OPTION]...\n\nOPTIONS") options)
-        Left (InvalidArgument flag value) -> tryHelp ("invalid argument `" ++ value ++ "' for `--" ++ flag ++ "'\n")
+        Left (InvalidArgument flag value) -> tryHelp ("invalid argument `" ++ value ++ "' for `--" ++ flag ++ "'")
         Right x -> Right x
-    (_, _, err:_)  -> tryHelp err
-    (_, arg:_, _)  -> tryHelp ("unexpected argument `" ++ arg ++ "'\n")
+    (_, _, err:_)  -> tryHelp (init err)
+    (_, arg:_, _)  -> tryHelp ("unexpected argument `" ++ arg ++ "'")
   where
-    tryHelp msg = Left (ExitFailure 1, prog ++ ": " ++ msg ++ "Try `" ++ prog ++ " --help' for more information.\n")
+    tryHelp msg = Left (ExitFailure 1, prog ++ ": " ++ msg ++ source ++ "\nTry `" ++ prog ++ " --help' for more information.\n")

--- a/hspec-core/test/Test/Hspec/OptionsSpec.hs
+++ b/hspec-core/test/Test/Hspec/OptionsSpec.hs
@@ -18,7 +18,8 @@ spec :: Spec
 spec = do
   describe "parseOptions" $ do
 
-    let parseOptions = Options.parseOptions defaultConfig "my-spec"
+    let parseOps = Options.parseOptions defaultConfig "my-spec"
+        parseOptions = parseOps ""
 
     it "sets configColorMode to ColorAuto" $ do
       configColorMode <$> parseOptions [] `shouldBe` Right ColorAuto
@@ -39,6 +40,10 @@ spec = do
       context "when given an invalid argument" $ do
         it "returns an error message" $ do
           fromLeft (parseOptions ["--qc-max-success", "foo"]) `shouldBe` (ExitFailure 1, "my-spec: invalid argument `foo' for `--qc-max-success'\nTry `my-spec --help' for more information.\n")
+
+      context "appends source to error message" $ do
+        it "returns an error message with source specified" $ do
+          fromLeft (parseOps " (defined in ./.hspec)" ["--qc-max-success", "foo"]) `shouldBe` (ExitFailure 1, "my-spec: invalid argument `foo' for `--qc-max-success' (defined in ./.hspec)\nTry `my-spec --help' for more information.\n")
 
     context "with --depth" $ do
       it "sets depth parameter for SmallCheck" $ do


### PR DESCRIPTION
Reads options from global `~/.hspec` and local `./.hspec` files with following priority: global < local < direct args.
For invalid options it also prints the source of issue, like 

> unrecognized option `--foo' (defined in /Users/Smelkov/.hspec)

Some workaround with test env is required because hspec-core applied global options to itself while testing, but seems fine with hspec package though.

Resolves #260