### PR TITLE
Block until finalizers return

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Util.hs
+++ b/hspec-core/src/Test/Hspec/Core/Util.hs
@@ -129,4 +129,13 @@ formatException err@(SomeException e) = case fromException err of
 -- occurs, the exception is returned instead.  Unlike `try` it is agnostic to
 -- asynchronous exceptions.
 safeTry :: IO a -> IO (Either SomeException a)
-safeTry action = withAsync (action >>= evaluate) waitCatch
+safeTry action =
+  bracket (async ((action >>= evaluate)))
+          -- It is important to wait here to make sure all finalizers
+          -- in action have been run. Otherwise the main thread can
+          -- exit before they have finished and the finalizers are
+          -- only partially run.
+          (\a -> cancel a >> waitCatch a) -- We use waitCatch to hide
+                                          -- the ThreadKilled
+                                          -- exception
+          waitCatch


### PR DESCRIPTION
This was the bug I originally thought was caused by #269 (I am pretty sure there is still a separate issue when running in parallel).

The problem is that when the main thread exits all other threads are killed instantly without even being noticed about it. `withAsync` helps somewhat as it throws an exception to these threads. However it returns after the exception has been raised which does not mean that the finalizers have finished running. You thus run into cases where your finalizer is abruptly terminated somewhere in the middle. By waiting we make sure that all the finalizers have been run.

Obviously this means that we can deadlock if a finalizer never returns, but that is always the case for `bracket` and imho leaking resources (in my case I was leaking temporary databases) is a lot worse.

I made a [simple example](https://gist.github.com/cocreature/f7a6e1b08face3911222202ca84ae812) to illustrate the problem.