### PR TITLE
Include the real changelog in  the package tarball

### DIFF
--- a/hspec.cabal
+++ b/hspec.cabal
@@ -32,7 +32,7 @@ description:      Hspec is a testing framework for Haskell. It is inspired by
                   The Hspec Manual is at <http://hspec.github.io/>.
 
 extra-source-files:
-    changelog
+    CHANGES.markdown
 
 source-repository head
   type: git


### PR DESCRIPTION
Commit 5385d29e135b1125ccd0129901b9f65b8be6faef introduced a workaround because hackage at the time did not look for a changlog via the name "changes". Now it does, so the workaround can be dropped.