### PR TITLE
Print QuickCheck labels on successful test run.

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Formatters.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters.hs
@@ -104,7 +104,7 @@ silent = Formatter {
 , exampleGroupStarted = \_ _ -> return ()
 , exampleGroupDone    = return ()
 , exampleProgress     = \_ _ _ -> return ()
-, exampleSucceeded    = \_ -> return ()
+, exampleSucceeded    = \_ _ -> return ()
 , exampleFailed       = \_ _ -> return ()
 , examplePending      = \_ _  -> return ()
 , failedFormatter     = return ()
@@ -125,8 +125,10 @@ specdoc = silent {
     hPutStr h (formatProgress p)
     hFlush h
 
-, exampleSucceeded = \(nesting, requirement) -> withSuccessColor $ do
+, exampleSucceeded = \(nesting, requirement) info -> withSuccessColor $ do
     writeLine $ indentationFor nesting ++ requirement
+    forM_ (lines (fromMaybe "" info)) $ \infoLine ->
+      writeLine $ indentationFor nesting ++ infoLine
 
 , exampleFailed = \(nesting, requirement) _ -> withFailColor $ do
     n <- getFailCount
@@ -147,7 +149,7 @@ specdoc = silent {
 
 progress :: Formatter
 progress = silent {
-  exampleSucceeded = \_   -> withSuccessColor $ write "."
+  exampleSucceeded = \_ _ -> withSuccessColor $ write "."
 , exampleFailed    = \_ _ -> withFailColor    $ write "F"
 , examplePending   = \_ _ -> withPendingColor $ write "."
 , failedFormatter  = defaultFailedFormatter

--- a/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
@@ -158,7 +158,7 @@ data Formatter = Formatter {
 , exampleProgress     :: Handle -> Path -> Progress -> IO ()
 
 -- | evaluated after each successful example
-, exampleSucceeded    :: Path -> FormatM ()
+, exampleSucceeded    :: Path -> Maybe String -> FormatM ()
 
 -- | evaluated after each failed example
 , exampleFailed       :: Path -> Either SomeException FailureReason -> FormatM ()

--- a/hspec-core/src/Test/Hspec/Core/Runner.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner.hs
@@ -82,7 +82,7 @@ applyDryRun c
   | otherwise = id
   where
     markSuccess :: Item () -> Item ()
-    markSuccess item = item {itemExample = safeEvaluateExample Success}
+    markSuccess item = item {itemExample = safeEvaluateExample (Success Nothing)}
 
     removeCleanup :: SpecTree () -> SpecTree ()
     removeCleanup spec = case spec of

--- a/hspec-core/src/Test/Hspec/Core/Runner/Eval.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner/Eval.hs
@@ -131,9 +131,9 @@ run chan reportProgress_ c formatter specs = do
         formatResult :: FormatResult
         formatResult result = do
           case result of
-            Right Success -> do
+            Right (Success info) -> do
               increaseSuccessCount
-              exampleSucceeded formatter path
+              exampleSucceeded formatter path info
             Right (Pending reason) -> do
               increasePendingCount
               examplePending formatter path reason

--- a/hspec-core/test/Test/Hspec/Core/FormattersSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/FormattersSpec.hs
@@ -19,7 +19,7 @@ main = hspec spec
 testSpec :: H.Spec
 testSpec = do
   H.describe "Example" $ do
-    H.it "success"    (H.Success)
+    H.it "success"    (H.Success Nothing)
     H.it "fail 1"     (H.Failure Nothing $ H.Reason "fail message")
     H.it "pending"    (H.pendingWith "pending message")
     H.it "fail 2"     (H.Failure Nothing H.NoReason)

--- a/hspec-core/test/Test/Hspec/Core/SpecSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/SpecSpec.hs
@@ -45,7 +45,7 @@ spec = do
     it "takes an example of that behavior" $ do
       [Leaf item] <- runSpecM (H.it "whatever" True)
       Right r <- itemExample item defaultParams ($ ()) noOpProgressCallback
-      r `shouldBe` Success
+      r `shouldBe` (Success Nothing)
 
     it "adds source locations" $ do
       [Leaf item] <- runSpecM (H.it "foo" True)

--- a/hspec-discover/integration-test/with-io-formatter/Formatter.hs
+++ b/hspec-discover/integration-test/with-io-formatter/Formatter.hs
@@ -8,6 +8,6 @@ count :: IO Formatter
 count = do
   ref <- newIORef (0 :: Int)
   return silent {
-      exampleSucceeded = \_ -> liftIO (modifyIORef ref succ)
+      exampleSucceeded = \_ _ -> liftIO (modifyIORef ref succ)
     , footerFormatter = liftIO (readIORef ref) >>= writeLine . show
     }


### PR DESCRIPTION
* New field is introduced to the Result Success constructor.
   It is an optional field and could contain any textual information
   for the successful test result.
* The field has one use at the moment. For QuickCheck test cases:
   if a test case computes labels, labels and their occurrence
   information is rendered.

The motivation behind this change: The QuickCheck's property based
testing can be used well with traditional test design. Labels can
be used to mark the test partitions. Observing the distribution
of partitions could be useful when one investigates false
positive test runs.

Fixes: https://github.com/hspec/hspec/issues/297