### PR TITLE
README.markdown: Add a travis build badge

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,7 @@
 # Hspec: Behavior-Driven Development for Haskell
 
+[![Build Status](https://secure.travis-ci.org/hspec/hspec.svg?branch=master)](http://travis-ci.org/hspec/hspec)
+
 ## Getting started
 
 Install Hspec from Hackage.


### PR DESCRIPTION
Its nice to have a travis build badge on the readme, but if I follow that link, the build is actually mostly broken. Not sure why.

Update: This PR built without a problem. Not sure what was happening before.