### PR TITLE
Add trailing white space to property name output

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Formatters.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters.hs
@@ -141,7 +141,7 @@ specdoc = silent {
 } where
     indentationFor nesting = replicate (length nesting * 2) ' '
     formatProgress (current, total)
-      | total == 0 = show current ++ "\r"
+      | total == 0 = "                                    \r"
       | otherwise  = show current ++ "/" ++ show total ++ "\r"
 
 


### PR DESCRIPTION
If the test name for a property test was too short, the test count would
bleed through to the actual test output. Fix it by adding a fixed amount
of trailing whitespace.

Closes: https://github.com/hspec/hspec/issues/301