### PR TITLE
Don't import from Data.Typeable.Internal when possible (i.e., add support for GHC 8.2)

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Compat.hs
+++ b/hspec-core/src/Test/Hspec/Core/Compat.hs
@@ -51,7 +51,7 @@ import           Text.Read
 import           Data.IORef
 import           System.Environment
 
-import           Data.Typeable.Internal (tyConModule, tyConName)
+import           Data.Typeable (tyConModule, tyConName)
 import           Control.Concurrent
 
 #if !MIN_VERSION_base(4,6,0)


### PR DESCRIPTION
GHC 8.2 reshuffled around the internals of `Typeable` quite a bit, and as a result, `base` no longer exports the `Data.Typeable.Internal` module in that version. This causes `hspec-core` (and `hspec-meta`) to fail to build on GHC 8.2.

But this is quite easily fixable, as `hspec` is only using `Data.Typeable.Internal` to import `tyConModule` and `tyConName`, which have been exported from the public `Data.Typeable` interface since GHC 7.4. Thus, we only need import from `Data.Typeable.Internal` on very old GHCs.

While this fixes the `hspec-core` issue, I don't know how to make the same change to `hspec-meta`, as I don't know where it lives.