### PR TITLE
Change hspec-discover sort from lexicographic to to natural order

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -18,6 +18,9 @@
   - Add location information to `pending`
   - Make sure that progress output is always cleared (fixes #301)
   - Parse source locations from pattern match failures
+  - Automatically discovered specs are sorted in natural order, for example
+    `T1Spec`, `T2Spec`, `T10Spec`, `T20Spec`, instead of lexicographical order
+    `T10Spec`, `T1Spec`, `T20Spec`, `T2Spec`
 
 ## Changes in 2.4.4
   - Require quickcheck-io >= 0.2.0

--- a/hspec-discover/hspec-discover.cabal
+++ b/hspec-discover/hspec-discover.cabal
@@ -43,6 +43,7 @@ library
   exposed-modules:
       Test.Hspec.Discover.Config
       Test.Hspec.Discover.Run
+      Test.Hspec.Discover.Sort
   other-modules:
       Paths_hspec_discover
   default-language: Haskell2010
@@ -71,6 +72,7 @@ test-suite spec
       Helper
       Test.Hspec.Discover.ConfigSpec
       Test.Hspec.Discover.RunSpec
+      Test.Hspec.Discover.SortSpec
       Paths_hspec_discover
   build-depends:
       base ==4.*

--- a/hspec-discover/hspec-discover.cabal
+++ b/hspec-discover/hspec-discover.cabal
@@ -80,4 +80,5 @@ test-suite spec
     , filepath
     , hspec-discover
     , hspec-meta >=2.3.2
+    , QuickCheck >= 2.7
   default-language: Haskell2010

--- a/hspec-discover/package.yaml
+++ b/hspec-discover/package.yaml
@@ -46,3 +46,4 @@ tests:
     dependencies:
       - hspec-discover
       - hspec-meta >= 2.3.2
+      - QuickCheck >= 2.7

--- a/hspec-discover/src/Test/Hspec/Discover/Run.hs
+++ b/hspec-discover/src/Test/Hspec/Discover/Run.hs
@@ -30,6 +30,7 @@ import           System.Directory (doesDirectoryExist, getDirectoryContents, doe
 import           System.FilePath hiding (combine)
 
 import           Test.Hspec.Discover.Config
+import           Test.Hspec.Discover.Sort
 
 instance IsString ShowS where
   fromString = showString
@@ -141,7 +142,8 @@ isValidModuleChar :: Char -> Bool
 isValidModuleChar c = isAlphaNum c || c == '_' || c == '\''
 
 getFilesRecursive :: FilePath -> IO [FilePath]
-getFilesRecursive baseDir = sort <$> go []
+getFilesRecursive baseDir = sortOn naturalSortKey <$> go []
+
   where
     go :: FilePath -> IO [FilePath]
     go dir = do

--- a/hspec-discover/src/Test/Hspec/Discover/Run.hs
+++ b/hspec-discover/src/Test/Hspec/Discover/Run.hs
@@ -22,6 +22,7 @@ import           Control.Applicative
 import           Data.List
 import           Data.Char
 import           Data.Maybe
+import           Data.Ord
 import           Data.String
 import           System.Environment
 import           System.Exit
@@ -142,7 +143,7 @@ isValidModuleChar :: Char -> Bool
 isValidModuleChar c = isAlphaNum c || c == '_' || c == '\''
 
 getFilesRecursive :: FilePath -> IO [FilePath]
-getFilesRecursive baseDir = sortOn naturalSortKey <$> go []
+getFilesRecursive baseDir = sortBy (comparing naturalSortKey) <$> go []
 
   where
     go :: FilePath -> IO [FilePath]

--- a/hspec-discover/src/Test/Hspec/Discover/Sort.hs
+++ b/hspec-discover/src/Test/Hspec/Discover/Sort.hs
@@ -3,36 +3,20 @@ module Test.Hspec.Discover.Sort (
 , naturalSortKey
 ) where
 
+import           Control.Arrow
 import           Data.Char
 
 data NaturalSortChunk
-  = NumericChunk { chunkNum :: Integer, chunkStr :: String }
-  | StringChunk { chunkStr :: String }
-  deriving (Eq, Show)
+  = NumericChunk { chunkNum :: Integer, chunkStrLen :: Int }
+  | StringChunk { chunkLCStr :: String }
+  deriving (Eq, Ord, Show)
 
-instance Ord NaturalSortChunk where
-  compare (NumericChunk n1 s1) (NumericChunk n2 s2) =
-    compare n1 n2 ~> compareLength s1 s2 ~> compare s1 s2
-  compare (StringChunk s1) (StringChunk s2) = compare s1 s2
-  compare (NumericChunk _ _) (StringChunk _) = LT
-  compare (StringChunk _) (NumericChunk _ _) = GT
-
-(~>) :: Ordering -> Ordering -> Ordering
-EQ ~> a = a
-a ~> _ = a
-infixr 5 ~>
-
-compareLength :: [a] -> [b] -> Ordering
-compareLength [] [] = EQ
-compareLength [] _ = LT
-compareLength _ [] = GT
-compareLength (_:xs) (_:ys) = compareLength xs ys
-
-naturalSortKey :: String -> [NaturalSortChunk]
-naturalSortKey s@(c:_)
-  | isDigit c = NumericChunk (read num) num : naturalSortKey afterNum
-  | otherwise = StringChunk             str : naturalSortKey afterStr
-  where
-    (num, afterNum) = span  isDigit s
-    (str, afterStr) = break isDigit  s
-naturalSortKey _ = []
+naturalSortKey :: String -> ([NaturalSortChunk], String)
+naturalSortKey = chunks &&& id where
+  chunks s@(c:_)
+    | isDigit c = NumericChunk (read num) (length num) : chunks afterNum
+    | otherwise = StringChunk (map toLower str) : chunks afterStr
+    where
+      (num, afterNum) = span  isDigit s
+      (str, afterStr) = break isDigit s
+  chunks _ = []

--- a/hspec-discover/src/Test/Hspec/Discover/Sort.hs
+++ b/hspec-discover/src/Test/Hspec/Discover/Sort.hs
@@ -1,0 +1,38 @@
+module Test.Hspec.Discover.Sort (
+  NaturalSortChunk(..)
+, naturalSortKey
+) where
+
+import           Data.Char
+
+data NaturalSortChunk
+  = NumericChunk { chunkNum :: Integer, chunkStr :: String }
+  | StringChunk { chunkStr :: String }
+  deriving (Eq, Show)
+
+instance Ord NaturalSortChunk where
+  compare (NumericChunk n1 s1) (NumericChunk n2 s2) =
+    compare n1 n2 ~> compareLength s1 s2 ~> compare s1 s2
+  compare (StringChunk s1) (StringChunk s2) = compare s1 s2
+  compare (NumericChunk _ _) (StringChunk _) = LT
+  compare (StringChunk _) (NumericChunk _ _) = GT
+
+(~>) :: Ordering -> Ordering -> Ordering
+EQ ~> a = a
+a ~> _ = a
+infixr 5 ~>
+
+compareLength :: [a] -> [b] -> Ordering
+compareLength [] [] = EQ
+compareLength [] _ = LT
+compareLength _ [] = GT
+compareLength (_:xs) (_:ys) = compareLength xs ys
+
+naturalSortKey :: String -> [NaturalSortChunk]
+naturalSortKey s@(c:_)
+  | isDigit c = NumericChunk (read num) num : naturalSortKey afterNum
+  | otherwise = StringChunk             str : naturalSortKey afterStr
+  where
+    (num, afterNum) = span  isDigit s
+    (str, afterStr) = break isDigit  s
+naturalSortKey _ = []

--- a/hspec-discover/test/Test/Hspec/Discover/RunSpec.hs
+++ b/hspec-discover/test/Test/Hspec/Discover/RunSpec.hs
@@ -5,6 +5,7 @@ import           Helper
 import           System.IO
 import           System.Directory
 import           System.FilePath
+import           Data.List (sort)
 
 import           Test.Hspec.Discover.Run hiding (Spec)
 import qualified Test.Hspec.Discover.Run
@@ -29,10 +30,6 @@ spec = do
           "{-# LINE 1 \"test-data/nested-spec/Spec.hs\" #-}"
         , "{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}"
         , "module Main where"
-        , "import qualified Dir8.X64Spec"
-        , "import qualified Dir8.X128Spec"
-        , "import qualified Dir16.X48Spec"
-        , "import qualified Dir16.X160Spec"
         , "import qualified Foo.Bar.BazSpec"
         , "import qualified Foo.BarSpec"
         , "import qualified FooSpec"
@@ -41,11 +38,7 @@ spec = do
         , "main = hspec spec"
         , "spec :: Spec"
         , "spec = " ++ unwords [
-               "postProcessSpec \"test-data/nested-spec/Dir8/X64Spec.hs\" (describe \"Dir8.X64\" Dir8.X64Spec.spec)"
-          , ">> postProcessSpec \"test-data/nested-spec/Dir8/X128Spec.hs\" (describe \"Dir8.X128\" Dir8.X128Spec.spec)"
-          , ">> postProcessSpec \"test-data/nested-spec/Dir16/X48Spec.hs\" (describe \"Dir16.X48\" Dir16.X48Spec.spec)"
-          , ">> postProcessSpec \"test-data/nested-spec/Dir16/X160Spec.hs\" (describe \"Dir16.X160\" Dir16.X160Spec.spec)"
-          , ">> postProcessSpec \"test-data/nested-spec/Foo/Bar/BazSpec.hs\" (describe \"Foo.Bar.Baz\" Foo.Bar.BazSpec.spec)"
+               "postProcessSpec \"test-data/nested-spec/Foo/Bar/BazSpec.hs\" (describe \"Foo.Bar.Baz\" Foo.Bar.BazSpec.spec)"
           , ">> postProcessSpec \"test-data/nested-spec/Foo/BarSpec.hs\" (describe \"Foo.Bar\" Foo.BarSpec.spec)"
           , ">> postProcessSpec \"test-data/nested-spec/FooSpec.hs\" (describe \"Foo\" FooSpec.spec)"
           ]
@@ -70,12 +63,8 @@ spec = do
 
   describe "getFilesRecursive" $ do
     it "recursively returns all file entries of a given directory" $ do
-      getFilesRecursive "test-data" `shouldReturn` [
+      getFilesRecursive "test-data" `shouldReturn` sort [
           "empty-dir/Foo/Bar/Baz/.placeholder"
-        , "nested-spec/Dir8/X64Spec.hs"
-        , "nested-spec/Dir8/X128Spec.hs"
-        , "nested-spec/Dir16/X48Spec.hs"
-        , "nested-spec/Dir16/X160Spec.hs"
         , "nested-spec/Foo/Bar/BazSpec.hs"
         , "nested-spec/Foo/BarSpec.hs"
         , "nested-spec/FooSpec.hs"
@@ -113,7 +102,7 @@ spec = do
   describe "findSpecs" $ do
     it "finds specs" $ do
       let dir = "test-data/nested-spec"
-      findSpecs (dir </> "Spec.hs") `shouldReturn` [spec_ (dir </> "Dir8/X64Spec.hs") "Dir8.X64", spec_ (dir </> "Dir8/X128Spec.hs") "Dir8.X128", spec_ (dir </> "Dir16/X48Spec.hs") "Dir16.X48", spec_ (dir </> "Dir16/X160Spec.hs") "Dir16.X160", spec_ (dir </> "Foo/Bar/BazSpec.hs") "Foo.Bar.Baz", spec_ (dir </> "Foo/BarSpec.hs") "Foo.Bar", spec_ (dir </> "FooSpec.hs") "Foo"]
+      findSpecs (dir </> "Spec.hs") `shouldReturn` [spec_ (dir </> "Foo/Bar/BazSpec.hs") "Foo.Bar.Baz", spec_ (dir </> "Foo/BarSpec.hs") "Foo.Bar", spec_ (dir </> "FooSpec.hs") "Foo"]
 
   describe "driverWithFormatter" $ do
     it "generates a test driver that uses a custom formatter" $ do

--- a/hspec-discover/test/Test/Hspec/Discover/RunSpec.hs
+++ b/hspec-discover/test/Test/Hspec/Discover/RunSpec.hs
@@ -5,7 +5,6 @@ import           Helper
 import           System.IO
 import           System.Directory
 import           System.FilePath
-import           Data.List (sort)
 
 import           Test.Hspec.Discover.Run hiding (Spec)
 import qualified Test.Hspec.Discover.Run
@@ -30,6 +29,10 @@ spec = do
           "{-# LINE 1 \"test-data/nested-spec/Spec.hs\" #-}"
         , "{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}"
         , "module Main where"
+        , "import qualified Dir8.X64Spec"
+        , "import qualified Dir8.X128Spec"
+        , "import qualified Dir16.X48Spec"
+        , "import qualified Dir16.X160Spec"
         , "import qualified Foo.Bar.BazSpec"
         , "import qualified Foo.BarSpec"
         , "import qualified FooSpec"
@@ -38,7 +41,11 @@ spec = do
         , "main = hspec spec"
         , "spec :: Spec"
         , "spec = " ++ unwords [
-               "postProcessSpec \"test-data/nested-spec/Foo/Bar/BazSpec.hs\" (describe \"Foo.Bar.Baz\" Foo.Bar.BazSpec.spec)"
+               "postProcessSpec \"test-data/nested-spec/Dir8/X64Spec.hs\" (describe \"Dir8.X64\" Dir8.X64Spec.spec)"
+          , ">> postProcessSpec \"test-data/nested-spec/Dir8/X128Spec.hs\" (describe \"Dir8.X128\" Dir8.X128Spec.spec)"
+          , ">> postProcessSpec \"test-data/nested-spec/Dir16/X48Spec.hs\" (describe \"Dir16.X48\" Dir16.X48Spec.spec)"
+          , ">> postProcessSpec \"test-data/nested-spec/Dir16/X160Spec.hs\" (describe \"Dir16.X160\" Dir16.X160Spec.spec)"
+          , ">> postProcessSpec \"test-data/nested-spec/Foo/Bar/BazSpec.hs\" (describe \"Foo.Bar.Baz\" Foo.Bar.BazSpec.spec)"
           , ">> postProcessSpec \"test-data/nested-spec/Foo/BarSpec.hs\" (describe \"Foo.Bar\" Foo.BarSpec.spec)"
           , ">> postProcessSpec \"test-data/nested-spec/FooSpec.hs\" (describe \"Foo\" FooSpec.spec)"
           ]
@@ -63,8 +70,12 @@ spec = do
 
   describe "getFilesRecursive" $ do
     it "recursively returns all file entries of a given directory" $ do
-      getFilesRecursive "test-data" `shouldReturn` sort [
+      getFilesRecursive "test-data" `shouldReturn` [
           "empty-dir/Foo/Bar/Baz/.placeholder"
+        , "nested-spec/Dir8/X64Spec.hs"
+        , "nested-spec/Dir8/X128Spec.hs"
+        , "nested-spec/Dir16/X48Spec.hs"
+        , "nested-spec/Dir16/X160Spec.hs"
         , "nested-spec/Foo/Bar/BazSpec.hs"
         , "nested-spec/Foo/BarSpec.hs"
         , "nested-spec/FooSpec.hs"
@@ -102,7 +113,7 @@ spec = do
   describe "findSpecs" $ do
     it "finds specs" $ do
       let dir = "test-data/nested-spec"
-      findSpecs (dir </> "Spec.hs") `shouldReturn` [spec_ (dir </> "Foo/Bar/BazSpec.hs") "Foo.Bar.Baz", spec_ (dir </> "Foo/BarSpec.hs") "Foo.Bar", spec_ (dir </> "FooSpec.hs") "Foo"]
+      findSpecs (dir </> "Spec.hs") `shouldReturn` [spec_ (dir </> "Dir8/X64Spec.hs") "Dir8.X64", spec_ (dir </> "Dir8/X128Spec.hs") "Dir8.X128", spec_ (dir </> "Dir16/X48Spec.hs") "Dir16.X48", spec_ (dir </> "Dir16/X160Spec.hs") "Dir16.X160", spec_ (dir </> "Foo/Bar/BazSpec.hs") "Foo.Bar.Baz", spec_ (dir </> "Foo/BarSpec.hs") "Foo.Bar", spec_ (dir </> "FooSpec.hs") "Foo"]
 
   describe "driverWithFormatter" $ do
     it "generates a test driver that uses a custom formatter" $ do

--- a/hspec-discover/test/Test/Hspec/Discover/SortSpec.hs
+++ b/hspec-discover/test/Test/Hspec/Discover/SortSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
 module Test.Hspec.Discover.SortSpec (main, spec) where
 
 import           Helper
@@ -39,10 +38,10 @@ spec = do
     context "sorts" $ do
       it "for humans" $ do
         sortBy (<=>)
-          [ "z" ++ show @Int n ++ ".txt"
+          [ "z" ++ show (n :: Int) ++ ".txt"
           | n <- [1, 10] ++ [100..102] ++ [11..19] ++ [2] ++ [20] ++ [3..9]
           ] `shouldBe`
-          [ "z" ++ show @Int n ++ ".txt"
+          [ "z" ++ show (n :: Int) ++ ".txt"
           | n <- [1..20] ++ [100..102]
           ]
   where

--- a/hspec-discover/test/Test/Hspec/Discover/SortSpec.hs
+++ b/hspec-discover/test/Test/Hspec/Discover/SortSpec.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE TypeApplications #-}
+module Test.Hspec.Discover.SortSpec (main, spec) where
+
+import           Helper
+
+import           Data.List (sortOn)
+import           Data.Ord (comparing)
+
+import           Test.Hspec.Discover.Sort
+
+main :: IO ()
+main = hspec spec
+
+
+spec :: Spec
+spec = do
+  describe "naturalSortKey" $ do
+    context "compares" $ do
+      it "reflexively" $ do
+        "" <=> "" `shouldBe` EQ
+        "Hello2World" <=> "Hello2World" `shouldBe` EQ
+        "123Hello456" <=> "123Hello456" `shouldBe` EQ
+        "" <=> "" `shouldBe` EQ
+      it "empty first" $ do
+        "" <=> "Hello2World" `shouldBe` LT
+        "Hello2World" <=> "" `shouldBe` GT
+      it "numbers first" $ do
+        "Hello2World" <=> "Hello World" `shouldBe` LT
+        "Hello World" <=> "Hello2World" `shouldBe` GT
+      it "string segments" $ do
+        "Hello2World9" <=> "Hello2World!0" `shouldBe` LT
+        "Hello2World!0" <=> "Hello2World9" `shouldBe` GT
+      it "numeric segments" $ do
+        "3.1.415" <=> "3.14.15" `shouldBe` LT
+        "3.14.15" <=> "3.1.415" `shouldBe` GT
+      it "numeric ties by string" $ do
+        "Hello 02 World" <=> "Hello 002 World" `shouldBe` LT
+        "Hello 002 World" <=> "Hello 02 World" `shouldBe` GT
+    context "sorts" $ do
+      it "for humans" $ do
+        sortOn naturalSortKey
+          [ "z" ++ show @Int n ++ ".txt"
+          | n <- [1, 10] ++ [100..102] ++ [11..19] ++ [2] ++ [20] ++ [3..9]
+          ] `shouldBe`
+          [ "z" ++ show @Int n ++ ".txt"
+          | n <- [1..20] ++ [100..102]
+          ]
+  where
+    (<=>) = comparing naturalSortKey
+    infix 4 <=>

--- a/hspec-discover/test/Test/Hspec/Discover/SortSpec.hs
+++ b/hspec-discover/test/Test/Hspec/Discover/SortSpec.hs
@@ -3,7 +3,7 @@ module Test.Hspec.Discover.SortSpec (main, spec) where
 
 import           Helper
 
-import           Data.List (sortOn)
+import           Data.List (sortBy)
 import           Data.Ord (comparing)
 
 import           Test.Hspec.Discover.Sort
@@ -38,7 +38,7 @@ spec = do
         "Hello 002 World" <=> "Hello 02 World" `shouldBe` GT
     context "sorts" $ do
       it "for humans" $ do
-        sortOn naturalSortKey
+        sortBy (<=>)
           [ "z" ++ show @Int n ++ ".txt"
           | n <- [1, 10] ++ [100..102] ++ [11..19] ++ [2] ++ [20] ++ [3..9]
           ] `shouldBe`


### PR DESCRIPTION
I would like my tests to be [sorted for humans](https://blog.codinghorror.com/sorting-for-humans-natural-sort-order/). It seems easy to add to `hspec-discover`, would you consider something like this?