### PR TITLE
Add Semigroup instance for Summary, addresses hspec/hspec#336

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Runner.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner.hs
@@ -27,6 +27,7 @@ import           Test.Hspec.Core.Compat
 
 import           Control.Monad
 import           Data.Maybe
+import qualified Data.Semigroup as Sem
 import           System.IO
 import           System.Environment (getProgName, getArgs, withArgs)
 import           System.Exit
@@ -236,6 +237,9 @@ data Summary = Summary {
 , summaryFailures :: Int
 } deriving (Eq, Show)
 
+instance Sem.Semigroup Summary where
+ (Summary x1 x2) <> (Summary y1 y2) = Summary (x1 + y1) (x2 + y2)
+
 instance Monoid Summary where
   mempty = Summary 0 0
-  (Summary x1 x2) `mappend` (Summary y1 y2) = Summary (x1 + y1) (x2 + y2)
+  mappend = (Sem.<>)

--- a/hspec-core/src/Test/Hspec/Core/Runner.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner.hs
@@ -240,7 +240,6 @@ data Summary = Summary {
 , summaryFailures :: Int
 } deriving (Eq, Show)
 
-
 appendSummary :: Summary -> Summary -> Summary
 appendSummary (Summary x1 x2) (Summary y1 y2) = Summary (x1 + y1) (x2 + y2)
 
@@ -257,7 +256,7 @@ instance Monoid Summary where
 -- at some point `mappend` will be removed from `Monoid`
 #elif MIN_VERSION_base(4,9,0)
   mappend = (Sem.<>)
-#else // base < 4.9
+#else
 -- prior to GHC 8.0 / base-4.9 where no `Semigroup` class existed
   mappend = appendSummary
 #endif

--- a/hspec-core/src/Test/Hspec/Core/Runner.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner.hs
@@ -27,7 +27,10 @@ import           Test.Hspec.Core.Compat
 
 import           Control.Monad
 import           Data.Maybe
+#if MIN_VERSION_base(4,9,0)
+-- Data.Semigroup was added in base-4.9
 import qualified Data.Semigroup as Sem
+#endif
 import           System.IO
 import           System.Environment (getProgName, getArgs, withArgs)
 import           System.Exit
@@ -237,9 +240,24 @@ data Summary = Summary {
 , summaryFailures :: Int
 } deriving (Eq, Show)
 
+
+appendSummary :: Summary -> Summary -> Summary
+appendSummary (Summary x1 x2) (Summary y1 y2) = Summary (x1 + y1) (x2 + y2)
+
+#if MIN_VERSION_base(4,9,0)
 instance Sem.Semigroup Summary where
- (Summary x1 x2) <> (Summary y1 y2) = Summary (x1 + y1) (x2 + y2)
+  (<>) = appendSummary
+#endif
 
 instance Monoid Summary where
   mempty = Summary 0 0
+
+#if MIN_VERSION_base(4,11,0)
+-- starting with base-4.11, mappend definitions are redundant;
+-- at some point `mappend` will be removed from `Monoid`
+#elif MIN_VERSION_base(4,9,0)
   mappend = (Sem.<>)
+#else // base < 4.9
+-- prior to GHC 8.0 / base-4.9 where no `Semigroup` class existed
+  mappend = appendSummary
+#endif


### PR DESCRIPTION
Pretty straightforward migration, as suggested by:
- https://ghc.haskell.org/trac/ghc/wiki/Migration/8.4#SemigroupMonoidsuperclasses
- https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid#Writingcompatiblecode
  
[edit]
This change conditionally imports Data.Semigroup from base, if the base version is new enough (>= 4.9) to have it, and provides an instance for it. If the base version is older (< 4.9), then the code is equivalent to what it was before, providing no Semigroup instance. This is one of the suggested migration patterns put forward by the migration guide for those who do not wish to incur a dependency on `semigroups`.