### PR TITLE
Add Profunctor instance for SpecM

### DIFF
--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: cd0a31bd7edaf1f1a446581fe294f3b1ece7f6ad4c2b328ed847b570055241fa
+-- hash: b81b94506310bc08d6e1282c17048835790a2636944d63f65ea326efcc123a34
 
 name:             hspec-core
 version:          2.5.1
@@ -39,10 +39,12 @@ library
     , base >=4.5.0.0 && <5
     , call-stack
     , clock
+    , contravariant
     , deepseq
     , directory
     , filepath
     , hspec-expectations ==0.8.2.*
+    , profunctors
     , quickcheck-io >=0.2.0
     , random
     , setenv
@@ -97,12 +99,14 @@ test-suite spec
     , base >=4.5.0.0 && <5
     , call-stack
     , clock
+    , contravariant
     , deepseq
     , directory
     , filepath
     , hspec-expectations ==0.8.2.*
     , hspec-meta >=2.3.2
     , process
+    , profunctors
     , quickcheck-io >=0.2.0
     , random
     , setenv

--- a/hspec-core/package.yaml
+++ b/hspec-core/package.yaml
@@ -34,6 +34,8 @@ dependencies:
   - call-stack
   - directory
   - filepath
+  - contravariant
+  - profunctors
 
   - stm >= 2.2 # for asyc
   - array # for Diff

--- a/hspec-core/src/Test/Hspec/Core/Tree.hs
+++ b/hspec-core/src/Test/Hspec/Core/Tree.hs
@@ -19,6 +19,7 @@ import           Prelude ()
 import           Test.Hspec.Core.Compat
 
 import           Data.CallStack
+import           Data.Functor.Contravariant
 
 import           Test.Hspec.Core.Example
 
@@ -54,6 +55,17 @@ data Item a = Item {
   -- | Example for behavior
 , itemExample :: Params -> (ActionWith a -> IO ()) -> ProgressCallback -> IO Result
 }
+
+instance Contravariant Item where
+  contramap f item = item {itemExample = newExample}
+    where
+      oldExample = itemExample item
+      newExample params action = oldExample params $ action . contramapActionWith f
+
+-- | Contravariant instance for ActionWith, given this way because ActionWith is
+-- a type synonym
+contramapActionWith :: (b -> a) -> ActionWith a -> ActionWith b
+contramapActionWith f act = act . f
 
 -- | The @specGroup@ function combines a list of specs into a larger spec.
 specGroup :: String -> [SpecTree a] -> SpecTree a


### PR DESCRIPTION
Fixes #353.

I think with these changes some of the hooks like `around` might have a better implementation, and I'll explore this further.