### PR TITLE
Add build-tool-depends to hspec-discover:spec

### DIFF
--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: cd0a31bd7edaf1f1a446581fe294f3b1ece7f6ad4c2b328ed847b570055241fa
+-- hash: 56a17c4285a3c44f823db7e8731c28c0fc01b940ccb1727c292fed8c0bf95099
 
 name:             hspec-core
 version:          2.5.1
@@ -160,3 +160,5 @@ test-suite spec
       Test.Hspec.Core.UtilSpec
       Paths_hspec_core
   default-language: Haskell2010
+  build-tool-depends:
+      hspec-meta:hspec-meta-discover

--- a/hspec-core/package.yaml
+++ b/hspec-core/package.yaml
@@ -62,3 +62,6 @@ tests:
       - silently >= 1.2.4
       - process
       - temporary
+    verbatim: |
+      build-tool-depends:
+          hspec-meta:hspec-meta-discover

--- a/hspec-discover/hspec-discover.cabal
+++ b/hspec-discover/hspec-discover.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e95ddf08a197c51b530593153440994740febddf7d9c85a0f766aaf77aec0743
+-- hash: aee37b915326a1b45e831346368f6394ebb85e25484c55b64a297e43b1ba6353
 
 name:             hspec-discover
 version:          2.5.1
@@ -83,3 +83,5 @@ test-suite spec
     , hspec-discover
     , hspec-meta >=2.3.2
   default-language: Haskell2010
+  build-tool-depends:
+      hspec-meta:hspec-meta-discover

--- a/hspec-discover/package.yaml
+++ b/hspec-discover/package.yaml
@@ -47,3 +47,6 @@ tests:
       - hspec-discover
       - hspec-meta >= 2.3.2
       - QuickCheck >= 2.7
+    verbatim: |
+      build-tool-depends:
+          hspec-meta:hspec-meta-discover

--- a/hspec.cabal
+++ b/hspec.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: cc8037ab82f8277af7aee801270c02aa011721d8f32f563be1520d25c0590137
+-- hash: afc4967ab55ffa3a1c3302cf42e0467efb2eacfa951ed6c46d78a85330bcb18e
 
 name:             hspec
 version:          2.5.1
@@ -85,3 +85,5 @@ test-suite spec
   other-modules:
       Paths_hspec
   default-language: Haskell2010
+  build-tool-depends:
+      hspec-meta:hspec-meta-discover

--- a/package.yaml
+++ b/package.yaml
@@ -60,3 +60,6 @@ tests:
       - directory
       - stringbuilder
       - hspec-meta >= 2.3.2
+    verbatim: |
+      build-tool-depends:
+          hspec-meta:hspec-meta-discover


### PR DESCRIPTION
See http://cabal.readthedocs.io/en/latest/developing-packages.html?highlight=build-tools#pkg-field-build-tool-depends. This is proper way to make the test suite ensure that executable is on the PATH.