### PR TITLE
Improve diff performance

### DIFF
--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: fef917dc0cb43c6da4719fb2d080d28e01d8bc888b679a3fa1c61559f02d9848
+-- hash: ba41a22bf03e86b2dcfbc3ee96107cb1fde29bbbcd25d4c00e50c30f748b2a4d
 
 name:             hspec-core
 version:          2.6.0
@@ -142,6 +142,7 @@ test-suite spec
       Control.Concurrent.Async
       Data.Algorithm.Diff
       All
+      Data.Algorithm.DiffSpec
       Helper
       Mock
       Test.Hspec.Core.ClockSpec

--- a/hspec-core/test/Data/Algorithm/DiffSpec.hs
+++ b/hspec-core/test/Data/Algorithm/DiffSpec.hs
@@ -1,0 +1,32 @@
+module Data.Algorithm.DiffSpec (spec) where
+
+import           Data.Algorithm.Diff
+import           Helper hiding (First)
+
+spec :: Spec
+spec = do
+  describe "getDiff" $ do
+    it "both are empty" $ do
+      getDiff "" "" `shouldBe` []
+    it "first is empty" $ do
+      getDiff "str" "" `shouldBe` [First 's', First 't', First 'r']
+    it "second is empty" $ do
+      getDiff "" "str" `shouldBe` [Second 's', Second 't', Second 'r']
+
+    it "equal" $ do
+      getDiff "str" "str" `shouldBe` [Both 's' 's', Both 't' 't', Both 'r' 'r']
+    it "different element" $ do
+      getDiff "str" "sur" `shouldBe` [Both 's' 's', First 't', Second 'u', Both 'r' 'r']
+
+    it "mixed elements" $ do
+      getDiff [1, 2, 1, 2, 1, 2] [1, 2, 3, 1, 2, 3 :: Int]
+        `shouldBe` [Both 1 1, Both 2 2, First 1, First 2, Second 3, Both 1 1, Both 2 2, Second 3]
+    it "no common elements" $ do
+      getDiff [0 .. 4] [5 .. 9 :: Int]
+        `shouldBe` [ First 0, First 1, First 2, First 3, First 4
+                   , Second 5, Second 6, Second 7, Second 8, Second 9]
+
+    it "first is longer" $ do
+      getDiff "x" "zxcvb" `shouldBe` [Second 'z', Both 'x' 'x', Second 'c', Second 'v', Second 'b']
+    it "second is longer" $ do
+      getDiff "zxcvb" "x" `shouldBe` [First 'z', Both 'x' 'x', First 'c', First 'v', First 'b']

--- a/hspec-core/vendor/Data/Algorithm/Diff.hs
+++ b/hspec-core/vendor/Data/Algorithm/Diff.hs
@@ -27,6 +27,7 @@ module Data.Algorithm.Diff
 
 import Prelude hiding (pi)
 
+import Control.Applicative (liftA2)
 import Data.Array
 
 data DI = F | S | B deriving (Show, Eq)
@@ -46,7 +47,7 @@ lcs eq as bs = back lena lenb
           arAs = listArray (0, lena-1) as
           arBs = listArray (0, lenb-1) bs
 
-          dp = listArray ((0, 0), (lena, lenb)) $ step <$> [0..lena] <*> [0..lenb]
+          dp = listArray ((0, 0), (lena, lenb)) $ liftA2 step [0..lena] [0..lenb]
 
           step 0 0 = DL 0 B
           step 0 _ = DL 0 S


### PR DESCRIPTION
Hi,
I had a test in a project which compared something really big to something small. It made hspec freeze while reporting diff and easily allocated 50GB+.
I think this is related to #331 

I reimplemented the `lcs` function and now the whole thing behaves a lot better.