### PR TITLE
Formatters changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+.stack-work/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: required
 language: generic
 
 env:
-  - CABALVER=1.16 GHCVER=7.4.1
+  # Tests time out in these versions of GHC, for reasons unknown
+  # - CABALVER=1.16 GHCVER=7.4.1
+
   - CABALVER=1.16 GHCVER=7.4.2
   - CABALVER=1.16 GHCVER=7.6.1
   - CABALVER=1.16 GHCVER=7.6.2

--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -1,26 +1,26 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.32.0.
+-- This file has been generated from package.yaml by hpack version 0.31.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a20d6ae2db0faf77da76207c1c022c3ca012a9b17fa08b5afb82cb0a5561df2b
+-- hash: 5f91f4209b0966cff7c5d86a95a6c82d80704664d7a31e5f166faa9d58682758
 
-name:             hspec-core
-version:          2.7.1
-license:          MIT
-license-file:     LICENSE
-copyright:        (c) 2011-2019 Simon Hengel,
-                  (c) 2011-2012 Trystan Spangler,
-                  (c) 2011 Greg Weber
-maintainer:       Simon Hengel <sol@typeful.net>
-build-type:       Simple
-category:         Testing
-stability:        experimental
-bug-reports:      https://github.com/hspec/hspec/issues
-homepage:         http://hspec.github.io/
-synopsis:         A Testing Framework for Haskell
-description:      This package exposes internal types and functions that can be used to extend Hspec's functionality.
+name:           hspec-core
+version:        2.7.0
+synopsis:       A Testing Framework for Haskell
+description:    This package exposes internal types and functions that can be used to extend Hspec's functionality.
+category:       Testing
+stability:      experimental
+homepage:       http://hspec.github.io/
+bug-reports:    https://github.com/hspec/hspec/issues
+maintainer:     Simon Hengel <sol@typeful.net>
+copyright:      (c) 2011-2019 Simon Hengel,
+                (c) 2011-2012 Trystan Spangler,
+                (c) 2011 Greg Weber
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
 
 source-repository head
   type: git
@@ -28,28 +28,6 @@ source-repository head
   subdir: hspec-core
 
 library
-  hs-source-dirs:
-      src
-      vendor
-  ghc-options: -Wall
-  build-depends:
-      HUnit ==1.6.*
-    , QuickCheck >=2.13.1
-    , ansi-terminal >=0.5
-    , array
-    , base >=4.5.0.0 && <5
-    , call-stack
-    , clock >=0.7.1
-    , deepseq
-    , directory
-    , filepath
-    , hspec-expectations ==0.8.2.*
-    , quickcheck-io >=0.2.0
-    , random
-    , setenv
-    , stm >=2.2
-    , tf-random
-    , transformers >=0.2.2.0
   exposed-modules:
       Test.Hspec.Core.Spec
       Test.Hspec.Core.Hooks
@@ -73,47 +51,42 @@ library
       Test.Hspec.Core.Formatters.Monad
       Test.Hspec.Core.QuickCheckUtil
       Test.Hspec.Core.Runner.Eval
+      Test.Hspec.Core.Runner.Eval.Types
       Test.Hspec.Core.Spec.Monad
       Test.Hspec.Core.Timer
       Test.Hspec.Core.Tree
       Control.Concurrent.Async
       Data.Algorithm.Diff
       Paths_hspec_core
+  hs-source-dirs:
+      src
+      vendor
+  ghc-options: -Wall
+  build-depends:
+      HUnit ==1.6.*
+    , QuickCheck ==2.12.*
+    , ansi-terminal >=0.5
+    , array
+    , base >=4.5.0.0 && <5
+    , bifunctors
+    , call-stack
+    , clock
+    , deepseq
+    , directory
+    , filepath
+    , hspec-expectations ==0.8.2.*
+    , quickcheck-io >=0.2.0
+    , random
+    , semigroups
+    , setenv
+    , stm >=2.2
+    , tf-random
+    , transformers >=0.2.2.0
   default-language: Haskell2010
 
 test-suite spec
   type: exitcode-stdio-1.0
   main-is: Spec.hs
-  hs-source-dirs:
-      src
-      vendor
-      test
-  ghc-options: -Wall
-  cpp-options: -DTEST
-  build-depends:
-      HUnit ==1.6.*
-    , QuickCheck >=2.13.1
-    , ansi-terminal >=0.5
-    , array
-    , base >=4.5.0.0 && <5
-    , call-stack
-    , clock >=0.7.1
-    , deepseq
-    , directory
-    , filepath
-    , hspec-expectations ==0.8.2.*
-    , hspec-meta >=2.3.2
-    , process
-    , quickcheck-io >=0.2.0
-    , random
-    , setenv
-    , silently >=1.2.4
-    , stm >=2.2
-    , temporary
-    , tf-random
-    , transformers >=0.2.2.0
-  build-tool-depends:
-      hspec-meta:hspec-meta-discover
   other-modules:
       Test.Hspec.Core.Clock
       Test.Hspec.Core.Compat
@@ -134,6 +107,7 @@ test-suite spec
       Test.Hspec.Core.QuickCheckUtil
       Test.Hspec.Core.Runner
       Test.Hspec.Core.Runner.Eval
+      Test.Hspec.Core.Runner.Eval.Types
       Test.Hspec.Core.Spec
       Test.Hspec.Core.Spec.Monad
       Test.Hspec.Core.Timer
@@ -162,4 +136,36 @@ test-suite spec
       Test.Hspec.Core.TimerSpec
       Test.Hspec.Core.UtilSpec
       Paths_hspec_core
+  hs-source-dirs:
+      src
+      vendor
+      test
+  ghc-options: -Wall
+  cpp-options: -DTEST
+  build-tool-depends:
+      hspec-meta:hspec-meta-discover
+  build-depends:
+      HUnit ==1.6.*
+    , QuickCheck ==2.12.*
+    , ansi-terminal >=0.5
+    , array
+    , base >=4.5.0.0 && <5
+    , bifunctors
+    , call-stack
+    , clock
+    , deepseq
+    , directory
+    , filepath
+    , hspec-expectations ==0.8.2.*
+    , hspec-meta >=2.3.2
+    , process
+    , quickcheck-io >=0.2.0
+    , random
+    , semigroups
+    , setenv
+    , silently >=1.2.4
+    , stm >=2.2
+    , temporary
+    , tf-random
+    , transformers >=0.2.2.0
   default-language: Haskell2010

--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5f91f4209b0966cff7c5d86a95a6c82d80704664d7a31e5f166faa9d58682758
+-- hash: de87aadde18a0651538a768fcd95b85ecdfbe1d16e6770be9a47c857decb8015
 
 name:           hspec-core
 version:        2.7.0
@@ -32,7 +32,9 @@ library
       Test.Hspec.Core.Spec
       Test.Hspec.Core.Hooks
       Test.Hspec.Core.Runner
+      Test.Hspec.Core.Format
       Test.Hspec.Core.Formatters
+      Test.Hspec.Core.Formatters.Diff
       Test.Hspec.Core.QuickCheck
       Test.Hspec.Core.Util
   other-modules:
@@ -44,8 +46,6 @@ library
       Test.Hspec.Core.Example
       Test.Hspec.Core.Example.Location
       Test.Hspec.Core.FailureReport
-      Test.Hspec.Core.Format
-      Test.Hspec.Core.Formatters.Diff
       Test.Hspec.Core.Formatters.Free
       Test.Hspec.Core.Formatters.Internal
       Test.Hspec.Core.Formatters.Monad

--- a/hspec-core/package.yaml
+++ b/hspec-core/package.yaml
@@ -48,7 +48,9 @@ library:
     - Test.Hspec.Core.Spec
     - Test.Hspec.Core.Hooks
     - Test.Hspec.Core.Runner
+    - Test.Hspec.Core.Format
     - Test.Hspec.Core.Formatters
+    - Test.Hspec.Core.Formatters.Diff
     - Test.Hspec.Core.QuickCheck
     - Test.Hspec.Core.Util
 

--- a/hspec-core/package.yaml
+++ b/hspec-core/package.yaml
@@ -19,6 +19,8 @@ ghc-options: -Wall
 
 dependencies:
   - base >= 4.5.0.0 && < 5
+  - bifunctors
+  - semigroups
   - random
   - tf-random
   - setenv

--- a/hspec-core/src/Test/Hspec/Core/Compat.hs
+++ b/hspec-core/src/Test/Hspec/Core/Compat.hs
@@ -11,6 +11,7 @@ module Test.Hspec.Core.Compat (
 , module Control.Applicative
 , module Control.Monad
 , module Data.Foldable
+, module Data.Semigroup
 , module Data.Traversable
 , module Data.Monoid
 , module Data.List
@@ -20,6 +21,7 @@ module Test.Hspec.Core.Compat (
 , atomicWriteIORef
 #endif
 , interruptible
+, tryReadMVar
 ) where
 
 import           Control.Applicative
@@ -34,8 +36,9 @@ import           Control.Monad hiding (
   )
 import           Data.Foldable
 import           Data.Traversable
-import           Data.Monoid
+import           Data.Monoid (First(..), Monoid(..), mconcat)
 import           Data.List (intercalate)
+import           Data.Semigroup (Semigroup(..))
 
 import           Prelude hiding (
     all
@@ -138,4 +141,14 @@ interruptible act = do
     Unmasked              -> act
     MaskedInterruptible   -> unsafeUnmask act
     MaskedUninterruptible -> act
+#endif
+
+#if !MIN_VERSION_base(4,7,0)
+tryReadMVar :: MVar a -> IO (Maybe a)
+tryReadMVar m = do
+  x <- tryTakeMVar m
+  case x of
+    Just v -> putMVar m v
+    _ -> return ()
+  return x
 #endif

--- a/hspec-core/src/Test/Hspec/Core/Config.hs
+++ b/hspec-core/src/Test/Hspec/Core/Config.hs
@@ -3,7 +3,6 @@ module Test.Hspec.Core.Config (
   Config (..)
 , ColorMode(..)
 , defaultConfig
-, FormattersList
 , defaultFormatters
 , readConfig
 , configAddFilter
@@ -32,6 +31,7 @@ import qualified Test.QuickCheck as QC
 import           Test.Hspec.Core.Util
 import           Test.Hspec.Core.Config.Options
 import           Test.Hspec.Core.FailureReport
+import           Test.Hspec.Core.Format
 import           Test.Hspec.Core.QuickCheckUtil (mkGen)
 import           Test.Hspec.Core.Example (Params(..), defaultParams)
 
@@ -107,7 +107,7 @@ configQuickCheckArgs c = qcArgs
 -- @
 -- `System.Environment.getArgs` >>= readConfig `defaultConfig`
 -- @
-readConfig :: FormattersList -> Config -> [String] -> IO Config
+readConfig :: [(String, IO SomeFormat)] -> Config -> [String] -> IO Config
 readConfig formatterChoices opts_ args = do
   prog <- getProgName
   configFiles <- do

--- a/hspec-core/src/Test/Hspec/Core/Config.hs
+++ b/hspec-core/src/Test/Hspec/Core/Config.hs
@@ -3,6 +3,8 @@ module Test.Hspec.Core.Config (
   Config (..)
 , ColorMode(..)
 , defaultConfig
+, FormattersList
+, defaultFormatters
 , readConfig
 , configAddFilter
 , configQuickCheckArgs
@@ -105,16 +107,16 @@ configQuickCheckArgs c = qcArgs
 -- @
 -- `System.Environment.getArgs` >>= readConfig `defaultConfig`
 -- @
-readConfig :: Config -> [String] -> IO Config
-readConfig opts_ args = do
+readConfig :: FormattersList -> Config -> [String] -> IO Config
+readConfig formatterChoices opts_ args = do
   prog <- getProgName
   configFiles <- do
-    ignore <- ignoreConfigFile opts_ args
+    ignore <- ignoreConfigFile formatterChoices opts_ args
     case ignore of
       True -> return []
       False -> readConfigFiles
   envVar <- fmap words <$> lookupEnv envVarName
-  case parseOptions opts_ prog configFiles envVar args of
+  case parseOptions formatterChoices opts_ prog configFiles envVar args of
     Left (err, msg) -> exitWithMessage err msg
     Right opts -> return opts
 

--- a/hspec-core/src/Test/Hspec/Core/Config/Options.hs
+++ b/hspec-core/src/Test/Hspec/Core/Config/Options.hs
@@ -19,6 +19,7 @@ import           System.Exit
 import           System.Console.GetOpt
 
 import           Test.Hspec.Core.Formatters
+import           Test.Hspec.Core.Format (Format(..), SomeFormat(..))
 import           Test.Hspec.Core.Formatters.Internal ()
 import           Test.Hspec.Core.Config.Util
 import           Test.Hspec.Core.Util

--- a/hspec-core/src/Test/Hspec/Core/Config/Options.hs
+++ b/hspec-core/src/Test/Hspec/Core/Config/Options.hs
@@ -54,6 +54,7 @@ data Config = Config {
 , configColorMode :: ColorMode
 , configDiff :: Bool
 , configFormatter :: Maybe Formatter
+, configAsyncFormatting :: Bool
 , configHtmlOutput :: Bool
 , configOutputFile :: Either Handle FilePath
 , configConcurrentJobs :: Maybe Int
@@ -80,6 +81,7 @@ defaultConfig = Config {
 , configColorMode = ColorAuto
 , configDiff = True
 , configFormatter = Nothing
+, configAsyncFormatting = False
 , configHtmlOutput = False
 , configOutputFile = Left stdout
 , configConcurrentJobs = Nothing
@@ -155,23 +157,24 @@ formatterOptions = concat [
   , [Option [] ["print-cpu-time"] (NoArg setPrintCpuTime) "include used CPU time in summary"]
   ]
   where
-    formatters :: [(String, Formatter)]
+    formatters :: [(String, (Formatter, Bool))]
     formatters = [
-        ("specdoc", specdoc)
-      , ("progress", progress)
-      , ("failed-examples", failed_examples)
-      , ("silent", silent)
-      , ("trace", trace)
+        ("specdoc", (specdoc, False))
+      , ("progress", (progress, False))
+      , ("failed-examples", (failed_examples, False))
+      , ("silent", (silent, False))
+      , ("trace", (trace, False))
+      , ("traceAsync", (trace, True))
       ]
 
     helpForFormat :: String
     helpForFormat = "use a custom formatter; this can be one of " ++ (formatOrList $ map fst formatters)
 
-    readFormatter :: String -> Maybe Formatter
+    readFormatter :: String -> Maybe (Formatter, Bool)
     readFormatter = (`lookup` formatters)
 
-    setFormatter :: Formatter -> Config -> Config
-    setFormatter f c = c {configFormatter = Just f}
+    setFormatter :: (Formatter, Bool) -> Config -> Config
+    setFormatter (f, async) c = c {configFormatter = Just f, configAsyncFormatting = async}
 
     setColor :: Bool -> Config -> Config
     setColor v config = config {configColorMode = if v then ColorAlways else ColorNever}

--- a/hspec-core/src/Test/Hspec/Core/Config/Options.hs
+++ b/hspec-core/src/Test/Hspec/Core/Config/Options.hs
@@ -161,6 +161,7 @@ formatterOptions = concat [
       , ("progress", progress)
       , ("failed-examples", failed_examples)
       , ("silent", silent)
+      , ("trace", trace)
       ]
 
     helpForFormat :: String

--- a/hspec-core/src/Test/Hspec/Core/Format.hs
+++ b/hspec-core/src/Test/Hspec/Core/Format.hs
@@ -6,6 +6,7 @@ module Test.Hspec.Core.Format (
 , SomeFormat(..)
 , FormatConfig(..)
 , IsFormatter(..)
+, LifeCycle(..)
 , Progress
 , Path
 , Location(..)
@@ -20,7 +21,7 @@ import           Control.Monad.IO.Class
 import           System.IO (Handle)
 import           Test.Hspec.Core.Compat
 import           Test.Hspec.Core.Spec (Location(..))
-import           Test.Hspec.Core.Example (FailureReason(..), LifeCycle, Progress)
+import           Test.Hspec.Core.Example (FailureReason(..), LifeCycle(..), Progress)
 import           Test.Hspec.Core.Util (Path)
 import           Test.Hspec.Core.Clock
 

--- a/hspec-core/src/Test/Hspec/Core/Format.hs
+++ b/hspec-core/src/Test/Hspec/Core/Format.hs
@@ -10,8 +10,8 @@ module Test.Hspec.Core.Format (
 , FailureReason(..)
 ) where
 
-import           Test.Hspec.Core.Spec (Progress, Location(..))
-import           Test.Hspec.Core.Example (FailureReason(..))
+import           Test.Hspec.Core.Spec (Location(..))
+import           Test.Hspec.Core.Example (FailureReason(..), LifeCycle, Progress)
 import           Test.Hspec.Core.Util (Path)
 import           Test.Hspec.Core.Clock
 
@@ -31,6 +31,6 @@ data Format m = Format {
   formatRun :: forall a. m a -> IO a
 , formatGroupStarted :: Path -> m ()
 , formatGroupDone :: Path -> m ()
-, formatProgress :: Path -> Progress -> m ()
+, formatProgress :: Path -> LifeCycle Progress -> m ()
 , formatItem :: Path -> Item -> m ()
 }

--- a/hspec-core/src/Test/Hspec/Core/Format.hs
+++ b/hspec-core/src/Test/Hspec/Core/Format.hs
@@ -1,6 +1,11 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 module Test.Hspec.Core.Format (
   Format(..)
+, SomeFormat(..)
+, FormatConfig(..)
+, IsFormatter(..)
 , Progress
 , Path
 , Location(..)
@@ -10,6 +15,10 @@ module Test.Hspec.Core.Format (
 , FailureReason(..)
 ) where
 
+import           Prelude ()
+import           Control.Monad.IO.Class
+import           System.IO (Handle)
+import           Test.Hspec.Core.Compat
 import           Test.Hspec.Core.Spec (Location(..))
 import           Test.Hspec.Core.Example (FailureReason(..), LifeCycle, Progress)
 import           Test.Hspec.Core.Util (Path)
@@ -28,9 +37,39 @@ data Result =
   | Failure FailureReason
 
 data Format m = Format {
-  formatRun :: forall a. m a -> IO a
+  formatRun  :: forall a. m a -> IO a
 , formatGroupStarted :: Path -> m ()
 , formatGroupDone :: Path -> m ()
 , formatProgress :: Path -> LifeCycle Progress -> m ()
 , formatItem :: Path -> Item -> m ()
+  -- | Whether the formatter wants to be notified asynchronously
+, formatAsynchronously :: Bool
 }
+
+-- TODO Rename to Formatter
+data SomeFormat where
+  SomeFormat :: (Applicative m, MonadIO m) => Format m -> SomeFormat
+
+data FormatConfig = FormatConfig {
+  formatConfigHandle :: Handle
+, formatConfigUseColor :: Bool
+, formatConfigUseDiff :: Bool
+, formatConfigHtmlOutput :: Bool
+, formatConfigPrintCpuTime :: Bool
+, formatConfigUsedSeed :: Integer
+} deriving (Eq, Show)
+
+class IsFormatter a where
+  toFormatter :: FormatConfig -> a -> IO SomeFormat
+
+instance IsFormatter (IO SomeFormat) where
+  toFormatter _ = id
+
+instance IsFormatter SomeFormat where
+  toFormatter _ = return
+
+instance (Applicative m, MonadIO m) => IsFormatter (Format m) where
+  toFormatter _ = return . SomeFormat
+
+instance (Applicative m, MonadIO m) => IsFormatter (IO (Format m)) where
+  toFormatter _ = fmap SomeFormat

--- a/hspec-core/src/Test/Hspec/Core/Formatters.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters.hs
@@ -6,11 +6,8 @@
 -- `Test.Hspec.Runner.hspecWith`.
 module Test.Hspec.Core.Formatters (
 
--- * Primitive Format API
-  module Test.Hspec.Core.Format
-
 -- * Formatters
-, silent
+  silent
 , specdoc
 , progress
 , failed_examples
@@ -23,6 +20,7 @@ module Test.Hspec.Core.Formatters (
 -- Actions live in the `FormatM` monad.  It provides access to the runner state
 -- and primitives for appending to the generated report.
 , Formatter (..)
+, IsFormatter(..)
 , FailureReason (..)
 , FormatM
 
@@ -67,7 +65,6 @@ import           Prelude ()
 import           Test.Hspec.Core.Compat hiding (First)
 
 import           Data.Maybe
-import           Test.Hspec.Core.Format(Format(..), FormatConfig(..), IsFormatter(..), SomeFormat(..))
 import           Test.Hspec.Core.Util
 import           Test.Hspec.Core.Spec (Location(..))
 import           Text.Printf
@@ -108,6 +105,7 @@ import Test.Hspec.Core.Formatters.Monad (
   , missingChunk
   )
 
+import Test.Hspec.Core.Format (IsFormatter(..))
 import Test.Hspec.Core.Formatters.Internal () -- for the IsFormatter instance
 
 import           Test.Hspec.Core.Clock (Seconds(..))

--- a/hspec-core/src/Test/Hspec/Core/Formatters.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters.hs
@@ -54,6 +54,9 @@ module Test.Hspec.Core.Formatters (
 
 -- ** Helpers
 , formatException
+
+-- ** Develop
+, trace
 ) where
 
 import           Prelude ()
@@ -103,6 +106,19 @@ import Test.Hspec.Core.Formatters.Monad (
 import           Test.Hspec.Core.Clock (Seconds(..))
 
 import           Test.Hspec.Core.Formatters.Diff
+
+trace :: Formatter
+trace = silent {
+  headerFormatter     = writeLine "headerFormatter"
+, exampleGroupStarted = \tags name -> writeLine $ "group started " ++ show (tags, name)
+, exampleGroupDone    = writeLine "group done"
+, exampleProgress     = \path prog -> writeLine $ "progress" ++ show (path,prog)
+, exampleSucceeded    = \path name -> writeLine $ "success" ++ show (path, name)
+, exampleFailed       = \path name _reason -> writeLine $ "failure" ++ show (path,name)
+, examplePending      = \path name _reason -> writeLine $ "pending" ++ show (path,name)
+, failedFormatter     = writeLine "failed"
+, footerFormatter     = writeLine "footer"
+                  }
 
 silent :: Formatter
 silent = Formatter {

--- a/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
@@ -23,6 +23,7 @@ import           Control.Monad.IO.Class
 import           Data.Char (isSpace)
 import qualified System.CPUTime as CPUTime
 
+import           Test.Hspec.Core.Example (LifeCycle(..))
 import qualified Test.Hspec.Core.Formatters.Monad as M
 import           Test.Hspec.Core.Formatters.Monad (Environment(..), interpretWith, FailureRecord(..))
 import           Test.Hspec.Core.Format
@@ -37,8 +38,11 @@ formatterToFormat formatter config = Format {
     return a
 , formatGroupStarted = \ (nesting, name) -> interpret $ M.exampleGroupStarted formatter nesting name
 , formatGroupDone = \ _ -> interpret (M.exampleGroupDone formatter)
-, formatProgress = \ path progress -> when useColor $ do
-    interpret $ M.exampleProgress formatter path progress
+, formatProgress = \ path progress -> case progress of
+    Started p ->
+      when (p /= (0,0) && useColor) $ interpret $ M.exampleProgress formatter path p
+    Progress p -> when useColor $
+      interpret $ M.exampleProgress formatter path p
 , formatItem = \ path (Item loc _duration info result) -> do
     clearTransientOutput
     case result of

--- a/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
@@ -25,7 +25,6 @@ import           Control.Monad.IO.Class
 import           Data.Char (isSpace)
 import qualified System.CPUTime as CPUTime
 
-import           Test.Hspec.Core.Example (LifeCycle(..))
 import qualified Test.Hspec.Core.Formatters.Monad as M
 import           Test.Hspec.Core.Formatters.Monad (Environment(..), interpretWith, FailureRecord(..))
 import           Test.Hspec.Core.Format

--- a/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
@@ -30,8 +30,8 @@ import           Test.Hspec.Core.Formatters.Monad (Environment(..), interpretWit
 import           Test.Hspec.Core.Format
 import           Test.Hspec.Core.Clock
 
-formatterToFormat :: FormatConfig -> M.Formatter -> Format FormatM
-formatterToFormat config formatter = Format {
+formatterToFormat :: M.Formatter -> FormatConfig -> Format FormatM
+formatterToFormat formatter config = Format {
   formatRun = \action -> runFormatM config $ do
     interpret (M.headerFormatter formatter)
     a <- action `finally_` interpret (M.failedFormatter formatter)
@@ -62,10 +62,10 @@ formatterToFormat config formatter = Format {
 
 -- TODO Orphan instance
 instance IsFormatter M.Formatter where
-  toFormatter cfg = pure . SomeFormat . formatterToFormat cfg
+  toFormatter = toFormatter . formatterToFormat
 
 instance IsFormatter (IO M.Formatter) where
-  toFormatter cfg = fmap (SomeFormat . formatterToFormat cfg)
+  toFormatter = toFormatter . fmap formatterToFormat
 
 interpret :: M.FormatM a -> FormatM a
 interpret = interpretWith Environment {

--- a/hspec-core/src/Test/Hspec/Core/Runner.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner.hs
@@ -50,6 +50,7 @@ import qualified Test.QuickCheck as QC
 import           Test.Hspec.Core.Util (Path)
 import           Test.Hspec.Core.Spec
 import           Test.Hspec.Core.Config
+import           Test.Hspec.Core.Format (FormatConfig(..), SomeFormat(..))
 import           Test.Hspec.Core.Formatters
 import           Test.Hspec.Core.FailureReport
 import           Test.Hspec.Core.QuickCheckUtil

--- a/hspec-core/src/Test/Hspec/Core/Runner.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner.hs
@@ -47,7 +47,6 @@ import           Test.Hspec.Core.Util (Path)
 import           Test.Hspec.Core.Spec
 import           Test.Hspec.Core.Config
 import           Test.Hspec.Core.Formatters
-import           Test.Hspec.Core.Formatters.Internal
 import           Test.Hspec.Core.FailureReport
 import           Test.Hspec.Core.QuickCheckUtil
 
@@ -206,7 +205,7 @@ focusSpec config spec
 runSpec_ :: Config -> Spec -> IO Summary
 runSpec_ config spec = do
   withHandle config $ \h -> do
-    let formatter = fromMaybe specdoc (configFormatter config)
+    let formatter = fromMaybe (flip toFormatter specdoc) (configFormatter config)
         seed = (fromJust . configQuickCheckSeed) config
         qcArgs = configQuickCheckArgs config
 
@@ -232,11 +231,12 @@ runSpec_ config spec = do
         , formatConfigPrintCpuTime = configPrintCpuTime config
         , formatConfigUsedSeed =  seed
         }
+      SomeFormat f <- formatter formatConfig
+      let
         evalConfig = EvalConfig {
-          evalConfigFormat = formatterToFormat formatter formatConfig
+          evalConfigFormat = f
         , evalConfigConcurrentJobs = concurrentJobs
         , evalConfigFastFail = configFastFail config
-        , evalConfigAsyncFormatting = configAsyncFormatting config
         }
       runFormatter evalConfig filteredSpec
 

--- a/hspec-core/src/Test/Hspec/Core/Runner/Eval/Types.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner/Eval/Types.hs
@@ -1,0 +1,164 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE TypeFamilies               #-}
+
+#if MIN_VERSION_base(4,6,0) && !MIN_VERSION_base(4,7,0)
+-- Control.Concurrent.QSem is deprecated in base-4.6.0.*
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+#endif
+
+module Test.Hspec.Core.Runner.Eval.Types where
+
+import           Prelude ()
+import           Control.Applicative
+import           Control.Concurrent
+import qualified Control.Exception         as E
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Class
+import           Control.Monad.Trans.State hiding (State)
+import           Data.Bifunctor
+import           Data.Foldable
+import           Data.Functor.Compose
+import           Data.Traversable
+import           Test.Hspec.Core.Compat
+import           Test.Hspec.Core.Format    (Format (..))
+import           Test.Hspec.Core.Util
+
+-- * Semaphores
+
+data Semaphore = Semaphore {
+  semaphoreWait   :: IO ()
+, semaphoreSignal :: IO ()
+}
+
+instance Semigroup Semaphore where
+  sa <> sb = Semaphore (semaphoreWait sa >> semaphoreWait sb) (semaphoreSignal sb >> semaphoreSignal sa)
+
+instance Monoid Semaphore where
+  mempty = Semaphore (return ()) (return ())
+  mappend = (<>)
+
+newSem :: Int -> IO Semaphore
+newSem capacity = do
+  sem <- newQSem capacity
+  return $ Semaphore (waitQSem sem) (signalQSem sem)
+
+newFromMVar :: MVar() -> Semaphore
+newFromMVar mvar = Semaphore (takeMVar mvar) (putMVar mvar ())
+
+withSemaphore :: Semaphore -> IO c -> IO c
+withSemaphore Semaphore{..} = E.bracket_ semaphoreWait semaphoreSignal
+
+-- * AsyncCells
+
+-- | Computations built on top of read-only MVars
+data AsyncCell m a = AsyncCell
+  { -- | Blocking read and empty the cell. Equivalent to 'takeMVar'
+    asyncCellTake    :: m a
+    -- | Non blocking read and empty (if successful) the cell. Equivalent to 'tryTakeMVar'.
+    --   Requires judicious use. In computations with multiple MVars it almost always leads to deadlock.
+  , asyncCellTryTake :: m (Maybe a)
+    -- | Non blocking read the cell. Equivalent to 'tryReadMVar'
+  , asyncCellTryRead :: m (Maybe a)
+  }
+
+-- | Create a 'AsyncCell' of the contents of an 'MVar'
+--   Forcing the 'AsyncCell' will empty the 'MVar'
+asyncCellFromMVar :: MonadIO m => MVar a -> AsyncCell m a
+asyncCellFromMVar mvar = AsyncCell (liftIO $ takeMVar mvar) (liftIO $ tryTakeMVar mvar) (liftIO $ tryReadMVar mvar)
+
+-- | Like 'asyncCellFromMVar', but 'asyncCellTake' and 'asyncCellTryTake' never empty the cell
+asyncCellFromMVarAlwaysRead :: MonadIO m => MVar a -> AsyncCell m a
+asyncCellFromMVarAlwaysRead mvar = AsyncCell (liftIO $ readMVar mvar) (liftIO $ tryReadMVar mvar) (liftIO $ tryReadMVar mvar)
+
+asyncCellHoist :: (forall a. f a -> g a) -> AsyncCell f v -> AsyncCell g v
+asyncCellHoist hoist p = AsyncCell (hoist $ asyncCellTake p) (hoist $ asyncCellTryTake p) (hoist $ asyncCellTryRead p)
+
+unsafeAsyncCell :: m a -> m (Maybe a) -> AsyncCell m a
+unsafeAsyncCell ma mb_a = AsyncCell ma mb_a mb_a
+
+instance Functor m => Functor (AsyncCell m) where
+  fmap f (AsyncCell take_ tryTake tryRead) =
+    AsyncCell (fmap f take_) ((fmap . fmap) f tryTake) ((fmap . fmap) f tryRead)
+
+instance Applicative m => Applicative (AsyncCell m) where
+  pure x = AsyncCell (pure x) (pure $ pure x) (pure $ pure x)
+  pf <*> px =
+    AsyncCell
+      (asyncCellTake pf <*> asyncCellTake px)
+      (getCompose $ Compose (asyncCellTryTake pf) <*> Compose (asyncCellTryTake px))
+      (getCompose $ Compose (asyncCellTryRead pf) <*> Compose (asyncCellTryRead px))
+
+instance Monad m => Monad (AsyncCell m) where
+  return x = AsyncCell (return x) (return $ return x) (return $ return x)
+  pf >>= k =
+    AsyncCell
+      (asyncCellTake pf >>= asyncCellTake . k)
+      (asyncCellTryTake pf >>= maybe (return Nothing) (asyncCellTryTake . k))
+      (asyncCellTryRead pf >>= maybe (return Nothing) (asyncCellTryRead . k))
+
+instance MonadTrans AsyncCell where
+  lift m = AsyncCell m (Just `liftM` m) (Just `liftM` m)
+
+instance MonadIO m => MonadIO (AsyncCell m) where
+  liftIO m = AsyncCell (liftIO m) (Just `liftM` liftIO m) (Just `liftM` liftIO m)
+
+-- * Progress monoid
+
+data Parallel p a = Partial !p | Return !p !a
+
+isReturn :: Parallel p a -> Bool
+isReturn Return {} = True
+isReturn _         = False
+
+getPartial :: Parallel p a -> Maybe p
+getPartial (Partial p)  = Just p
+getPartial (Return p _) = Just p
+
+instance Functor (Parallel p) where fmap = fmapDefault
+instance Foldable (Parallel p) where foldMap = foldMapDefault
+instance Traversable (Parallel p) where
+  traverse _ (Partial p)= pure $ Partial p
+  traverse f (Return p x) = Return p <$> f x
+instance Bifunctor Parallel where
+  bimap l _ (Partial p)  = Partial (l p)
+  bimap l r (Return p a) = Return (l p) (r a)
+instance (Semigroup p, Semigroup a) => Semigroup (Parallel p a) where
+  Partial p1 <> Partial p2 = Partial (p1 <> p2)
+  Return p1 x <> Return p2 y = Return (p1 <> p2) (x <> y)
+  Partial p1 <> Return p2 x = Return (p1 <> p2) x
+  Return p1 x <> Partial p2 = Return (p1 <> p2) x
+instance (Monoid p, Semigroup p, Semigroup a) => Monoid (Parallel p a) where
+  mempty = Partial mempty
+  mappend = (<>)
+
+-- * Eval monad
+
+data EvalConfig m = EvalConfig {
+  evalConfigFormat          :: Format m
+, evalConfigConcurrentJobs  :: Int
+, evalConfigFastFail        :: Bool
+, evalConfigAsyncFormatting :: Bool
+}
+
+data State m = State {
+  stateConfig       :: EvalConfig m
+, stateSuccessCount :: Int
+, statePendingCount :: Int
+, stateFailures     :: [Path]
+}
+
+newtype EvalM m a = EvalM (StateT (State m) m a)
+  deriving (Applicative, Functor, Monad, MonadIO)
+
+instance (a ~ (), Monad m) => Semigroup (EvalM m a) where
+ (<>) = (>>)
+
+instance (a ~ (), Monad m) => Monoid (EvalM m a) where
+  mempty = return ()
+  mappend = (<>)
+
+instance MonadTrans EvalM where
+  lift = EvalM . lift

--- a/hspec-core/src/Test/Hspec/Core/Runner/Eval/Types.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner/Eval/Types.hs
@@ -140,7 +140,6 @@ data EvalConfig m = EvalConfig {
   evalConfigFormat          :: Format m
 , evalConfigConcurrentJobs  :: Int
 , evalConfigFastFail        :: Bool
-, evalConfigAsyncFormatting :: Bool
 }
 
 data State m = State {

--- a/hspec-core/test/Test/Hspec/Core/Config/OptionsSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/Config/OptionsSpec.hs
@@ -16,7 +16,7 @@ spec :: Spec
 spec = do
   describe "parseOptions" $ do
 
-    let parseOptions = Options.parseOptions defaultConfig "my-spec"
+    let parseOptions = Options.parseOptions defaultFormatters defaultConfig "my-spec"
 
     it "rejects unexpected arguments" $ do
       fromLeft (parseOptions [] Nothing ["foo"]) `shouldBe` (ExitFailure 1, "my-spec: unexpected argument `foo'\nTry `my-spec --help' for more information.\n")
@@ -115,13 +115,13 @@ spec = do
   describe "ignoreConfigFile" $ around_ (withEnvironment []) $ do
     context "by default" $ do
       it "returns False" $ do
-        ignoreConfigFile defaultConfig [] `shouldReturn` False
+        ignoreConfigFile defaultFormatters defaultConfig [] `shouldReturn` False
 
     context "with --ignore-dot-hspec" $ do
       it "returns True" $ do
-        ignoreConfigFile defaultConfig ["--ignore-dot-hspec"] `shouldReturn` True
+        ignoreConfigFile defaultFormatters defaultConfig ["--ignore-dot-hspec"] `shouldReturn` True
 
     context "with IGNORE_DOT_HSPEC" $ do
       it "returns True" $ do
         withEnvironment [("IGNORE_DOT_HSPEC", "yes")] $ do
-          ignoreConfigFile defaultConfig [] `shouldReturn` True
+          ignoreConfigFile defaultFormatters defaultConfig [] `shouldReturn` True

--- a/hspec-core/test/Test/Hspec/Core/FormattersSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/FormattersSpec.hs
@@ -115,7 +115,7 @@ spec = do
   describe "specdoc" $ do
     let
       formatter = H.specdoc
-      runSpec = captureLines . H.hspecWithResult H.defaultConfig {H.configFormatter = Just $ flip H.toFormatter formatter}
+      runSpec = captureLines . H.hspecWithResult H.defaultConfig {H.configFormatter = Just $ H.toFormatter formatter}
 
     it "displays a header for each thing being described" $ do
       _:x:_ <- runSpec testSpec
@@ -272,7 +272,7 @@ spec = do
 
 failed_examplesSpec :: H.Formatter -> Spec
 failed_examplesSpec formatter = do
-  let runSpec = captureLines . H.hspecWithResult H.defaultConfig {H.configFormatter = Just $ flip H.toFormatter formatter}
+  let runSpec = captureLines . H.hspecWithResult H.defaultConfig {H.configFormatter = Just $ H.toFormatter formatter}
 
   context "displays a detailed list of failures" $ do
     it "prints all requirements that are not met" $ do

--- a/hspec-core/test/Test/Hspec/Core/FormattersSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/FormattersSpec.hs
@@ -115,7 +115,7 @@ spec = do
   describe "specdoc" $ do
     let
       formatter = H.specdoc
-      runSpec = captureLines . H.hspecWithResult H.defaultConfig {H.configFormatter = Just formatter}
+      runSpec = captureLines . H.hspecWithResult H.defaultConfig {H.configFormatter = Just $ flip H.toFormatter formatter}
 
     it "displays a header for each thing being described" $ do
       _:x:_ <- runSpec testSpec
@@ -272,7 +272,7 @@ spec = do
 
 failed_examplesSpec :: H.Formatter -> Spec
 failed_examplesSpec formatter = do
-  let runSpec = captureLines . H.hspecWithResult H.defaultConfig {H.configFormatter = Just formatter}
+  let runSpec = captureLines . H.hspecWithResult H.defaultConfig {H.configFormatter = Just $ flip H.toFormatter formatter}
 
   context "displays a detailed list of failures" $ do
     it "prints all requirements that are not met" $ do

--- a/hspec-core/test/Test/Hspec/Core/Runner/EvalSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/Runner/EvalSpec.hs
@@ -11,6 +11,7 @@ import           Control.Monad.IO.Class
 import qualified Data.Foldable as F (toList)
 import           Data.List (permutations, sort)
 import           Test.Hspec.Core.Tree
+import           Test.Hspec.Core.Format as H (Format(..), FormatConfig(..), SomeFormat(..))
 import           Test.Hspec.Core.Formatters as H
 import           Test.Hspec.Core.Runner.Eval
 import qualified Test.Hspec.Core.Runner as H

--- a/hspec-core/test/Test/Hspec/Core/Runner/EvalSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/Runner/EvalSpec.hs
@@ -1,13 +1,30 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
 module Test.Hspec.Core.Runner.EvalSpec (spec) where
 
 import           Prelude ()
 import           Helper
 
+import           Control.Concurrent
+import           Control.Concurrent.Async
+import           Control.Monad.IO.Class
+import qualified Data.Foldable as F (toList)
+import           Data.List (permutations, sort)
 import           Test.Hspec.Core.Tree
+import           Test.Hspec.Core.Formatters
 import           Test.Hspec.Core.Runner.Eval
+import qualified Test.Hspec.Core.Runner as H
+import qualified Test.Hspec.Core.Spec as H
 
 spec :: Spec
 spec = do
+  let mkCfg f = do
+        (traceF, getLines) <- traceFormatterIO
+        let cfg = H.defaultConfig{H.configFormatter = Just traceF}
+        return (f cfg, getLines)
+      synchronousCfg n = mkCfg $ \cfg -> cfg{H.configConcurrentJobs = Just n, H.configAsyncFormatting = False}
+      parallelCfg   = mkCfg $ \cfg -> cfg{H.configConcurrentJobs = Just 8, H.configAsyncFormatting = True}
+
   describe "traverse" $ do
     context "when used with Tree" $ do
       let
@@ -18,12 +35,173 @@ spec = do
         traverse_ (modifyIORef ref . (:) ) tree
         reverse <$> readIORef ref `shouldReturn` [1 .. 4]
 
-  describe "runSequentially" $ do
-    it "runs actions sequentially" $ do
-      ref <- newIORef []
-      (_, actionA) <- runSequentially $ \ _ -> modifyIORef ref (23 :)
-      (_, actionB) <- runSequentially $ \ _ -> modifyIORef ref (42 :)
-      (_, ()) <- actionB (\_ -> return ())
-      readIORef ref `shouldReturn` [42 :: Int]
-      (_, ()) <- actionA (\_ -> return ())
-      readIORef ref `shouldReturn` [23, 42]
+  describe "synchronous reporting" $ do
+    describe "runSequentially" $ do
+      it "runs actions sequentially" $ do
+        ref <- newIORef []
+        (_, actionA) <- runSequentially mempty mempty $ \ _ -> threadDelay 10 >> modifyIORef ref (23 :)
+        threadDelay 20
+        (_, actionB) <- runSequentially mempty mempty $ \ _ -> threadDelay 10 >> modifyIORef ref (42 :)
+        void $ waitFor actionB
+        readIORef ref `shouldReturn` [42 :: Int]
+        void $ waitFor actionA
+        readIORef ref `shouldReturn` [23, 42]
+
+    context "without -j" $
+      modelProperty (synchronousCfg 1) "trace is sequential" (sequentialModel <$> resize 15 arbitrary) $
+        \model -> (`shouldBe` modelSequentialTrace model)
+
+  describe "asynchronous reporting" $
+    context "with -j" $
+      traceProperties parallelCfg
+  where
+    waitFor action = do
+      progress_ <- asyncCellTake action
+      case progress_ of
+        Return{}  -> return ()
+        Partial{} -> waitFor action
+
+
+traceProperties :: IO (H.Config, IO [FormatterLine]) -> Spec
+traceProperties mkCfg = do
+  traceProperty mkCfg "trace is a reordering of sequential trace" $ \model tr ->
+    sort tr == sort (modelSequentialTrace model)
+
+  traceProperty mkCfg "group starts before children" $ \_model ->
+    fst . flip foldl' (True, []) (\(allGood, groups) x -> case x of
+      ExampleGroupStarted path name -> (allGood, (path ++ [name]) : groups)
+      _ -> (allGood, groups))
+
+modelProperty :: IO (H.Config, IO t) -> String -> Gen (SpecModel ()) -> (SpecModel () -> t -> IO b) -> Spec
+modelProperty mkCfg name gen expectation = forAllUnique name gen $ \model -> ioProperty $ do
+  modelSpec <- modelPermutations model
+  forM_ (specInterleavings modelSpec) $ \p -> do
+    (cfg, getLines) <- mkCfg
+    H.hspecWith cfg (specDec modelSpec) `concurrently_` p
+    outputTrace <- getLines
+    expectation model outputTrace
+
+traceProperty :: Show a => IO (H.Config, IO a) -> String -> (SpecModel () -> a -> Bool) -> Spec
+traceProperty mkCfg name predicate =
+  modelProperty mkCfg name (resize 15 arbitrary) (\model -> (`shouldSatisfy` predicate model))
+
+------------------------------------------------------------------------------
+
+data FormatterLine
+  = ExampleGroupStarted [String] String
+  | ExampleGroupDone
+  | ExampleProgress H.Path (Int,Int)
+  | ExampleSucceeded H.Path String
+  | ExampleFailed  H.Path String String
+  | ExamplePending H.Path String (Maybe String)
+  deriving (Eq, Ord, Show)
+
+traceFormatterIO :: IO (Formatter, IO [FormatterLine])
+traceFormatterIO = do
+  ref <- newIORef []
+  let push x = liftIO $ modifyIORef' ref (x :)
+      f = silent
+        { exampleGroupStarted = (push.) . ExampleGroupStarted
+        , exampleGroupDone    = push ExampleGroupDone
+        , exampleProgress     = (push.) . ExampleProgress
+        , exampleSucceeded    = (push.) . ExampleSucceeded
+        , exampleFailed       = \path info reason -> push $ ExampleFailed path info (show reason)
+        , examplePending      = ((push.).) . ExamplePending
+        }
+  return (f, reverse <$> readIORef ref)
+
+------------------------------------------------------------------------------
+-- Hack to avoid checking a property with the same input more than once
+forAllUnique :: (Show t, Eq t) => String -> Gen t -> (t -> Property) -> Spec
+forAllUnique title gen prop =
+  -- there has to be a better way of doing this
+  beforeAll (newIORef []) $
+    it title $ \seenRef -> do
+      let alreadyChecked x = atomicModifyIORef seenRef $ \xx ->
+            if x`elem` xx then (xx, True) else (x : xx, False)
+      forAll gen $ \x -> ioProperty $ do
+        already <- alreadyChecked x
+        return $ if already then property Discard else prop x
+
+---------------------------------------------------
+
+data SpecModel  a = Describe {steps::[SpecModel' a], isParallel :: !Bool}
+  deriving (Eq, Show)
+
+instance Traversable SpecModel where
+  traverse f (Describe steps p) = flip Describe p <$> (traverse.traverse) f steps
+instance Foldable SpecModel where foldMap = foldMapDefault
+instance Functor SpecModel where fmap = fmapDefault
+
+data SpecModel' a = Success a | Nest (SpecModel a)
+  deriving (Eq, Show)
+
+instance Traversable SpecModel' where
+  traverse f (Success a)  = Success <$> f a
+  traverse f (Nest model) = Nest <$> traverse f model
+instance Foldable SpecModel' where foldMap = foldMapDefault
+instance Functor SpecModel' where fmap = fmapDefault
+
+sequentialModel :: SpecModel a -> SpecModel a
+sequentialModel (Describe steps _) = Describe (map go steps) False
+  where
+    go (Nest m) = Nest (sequentialModel m)
+    go x = x
+
+modelSequentialTrace :: SpecModel a -> [FormatterLine]
+modelSequentialTrace = go [] (1::Int) where
+  go _     _  steps | null $ F.toList steps = []
+  go path idx (Describe {steps}) =
+    ExampleGroupStarted path name :
+    concat (zipWith (go' (path++[name])) [1..] steps) ++
+    [ExampleGroupDone]
+    where
+      name = "Group " ++ show idx
+  go' path idx (Success _) =
+    [ ExampleSucceeded (path, "Example " ++ show idx) ""]
+  go' path idx (Nest model) = go path idx model
+
+genSpecModel :: Arbitrary a => Int -> Gen (SpecModel a)
+genSpecModel size = do
+  n <- choose (0, min 5 size)
+  steps <- vectorOf n (genSpecModel' (size `div` n))
+  Describe steps <$> arbitrary
+
+genSpecModel' :: Arbitrary a => Int -> Gen (SpecModel' a)
+genSpecModel' size = oneof $
+  [ Success <$> arbitrary ] ++
+  [ Nest <$> genSpecModel (size `div` 2) | size > 1]
+
+instance (Arbitrary a, Monoid a) => Arbitrary (SpecModel a) where
+  arbitrary =
+    sized genSpecModel `suchThat` \(Describe {steps}) -> not $ null(F.toList steps)
+  shrink (Describe steps isParallel) =
+    [Describe steps' isParallel | steps' <- shrink steps] ++
+    [Describe steps False | isParallel]
+
+instance (Arbitrary a, Monoid a) => Arbitrary (SpecModel' a) where
+  arbitrary = sized genSpecModel'
+  shrink (Nest x) = Success mempty : (Nest <$> shrink x)
+  shrink Success{} = []
+
+toSpec :: Int -> SpecModel (IO ()) -> H.Spec
+toSpec idx (Describe {steps, isParallel}) =
+  (if isParallel then H.parallel else id) $
+    H.describe ("Group " ++ show idx) . sequence_ $ zipWith toSpec' [1 ..] steps
+
+toSpec' :: Int -> SpecModel' (IO ()) -> H.Spec
+toSpec' idx (Success x) = H.it ("Example " ++ show idx) x
+toSpec' idx (Nest s) = toSpec idx s
+
+data SpecPermutations = SpecPermutations
+  { specDec  :: H.Spec           -- ^ A spec
+  , specInterleavings :: [IO ()] -- ^ All possible test completion orderings in 'specDec'
+  }
+
+modelPermutations :: SpecModel () -> IO SpecPermutations
+modelPermutations model = do
+  mvarsTree <- traverse (const newEmptyMVar) model
+  let mvars = toList mvarsTree
+      specDec = toSpec 1 $ takeMVar <$> mvarsTree
+      specInterleavings = traverse_ (\v -> threadDelay 2 >> putMVar v ()) <$> permutations mvars
+  return SpecPermutations {..}

--- a/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
@@ -25,7 +25,7 @@ import           System.Console.ANSI
 import           Test.Hspec.Core.FailureReport (FailureReport(..))
 import qualified Test.Hspec.Core.Spec as H
 import qualified Test.Hspec.Core.Runner as H
-import qualified Test.Hspec.Core.Formatters as H (silent)
+import qualified Test.Hspec.Core.Formatters as H (toFormatter, silent)
 import qualified Test.Hspec.Core.QuickCheck as H
 
 import qualified Test.QuickCheck as QC
@@ -45,8 +45,6 @@ spec = do
   describe "hspec" $ do
     context "synchronous formatting" $
       runnerSpec H.defaultConfig
-    context "asynchronous formatting" $
-      runnerSpec H.defaultConfig{H.configAsyncFormatting = True}
   describe "hspecResult" $
     hspecResultSpec
   describe "rerunAll" $
@@ -558,7 +556,7 @@ hspecResultSpec = do
       r `shouldBe` "Foo.Bar"
 
     it "can use a custom formatter" $ do
-      r <- capture_ . H.hspecWithResult H.defaultConfig {H.configFormatter = Just H.silent} $ do
+      r <- capture_ . H.hspecWithResult H.defaultConfig {H.configFormatter = Just $ flip H.toFormatter H.silent} $ do
         H.describe "Foo.Bar" $ do
           H.it "some example" True
       r `shouldBe` ""

--- a/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
@@ -556,7 +556,7 @@ hspecResultSpec = do
       r `shouldBe` "Foo.Bar"
 
     it "can use a custom formatter" $ do
-      r <- capture_ . H.hspecWithResult H.defaultConfig {H.configFormatter = Just $ flip H.toFormatter H.silent} $ do
+      r <- capture_ . H.hspecWithResult H.defaultConfig {H.configFormatter = Just $ H.toFormatter H.silent} $ do
         H.describe "Foo.Bar" $ do
           H.it "some example" True
       r `shouldBe` ""

--- a/hspec.cabal
+++ b/hspec.cabal
@@ -1,37 +1,37 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.0.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 82bc339ad7726a9fc53ee3731cd9e47f997a9d73e6297de54342d95744b1eaaa
+-- hash: 773d65e888e3a8b90bf93cb09c2965add2b428ed67f197ebd445d6fded409522
 
-name:             hspec
-version:          2.7.1
-license:          MIT
-license-file:     LICENSE
-copyright:        (c) 2011-2019 Simon Hengel,
-                  (c) 2011-2012 Trystan Spangler,
-                  (c) 2011 Greg Weber
-maintainer:       Simon Hengel <sol@typeful.net>
-build-type:       Simple
-category:         Testing
-stability:        experimental
-bug-reports:      https://github.com/hspec/hspec/issues
-homepage:         http://hspec.github.io/
-synopsis:         A Testing Framework for Haskell
-description:      Hspec is a testing framework for Haskell.  Some of Hspec's distinctive
-                  features are:
-                  .
-                  * a friendly DSL for defining tests
-                  .
-                  * integration with QuickCheck, SmallCheck, and HUnit
-                  .
-                  * parallel test execution
-                  .
-                  * automatic discovery of test files
-                  .
-                  The Hspec Manual is at <http://hspec.github.io/>.
+name:           hspec
+version:        2.7.1
+synopsis:       A Testing Framework for Haskell
+description:    Hspec is a testing framework for Haskell.  Some of Hspec's distinctive
+                features are:
+                .
+                * a friendly DSL for defining tests
+                .
+                * integration with QuickCheck, SmallCheck, and HUnit
+                .
+                * parallel test execution
+                .
+                * automatic discovery of test files
+                .
+                The Hspec Manual is at <http://hspec.github.io/>.
+category:       Testing
+stability:      experimental
+homepage:       http://hspec.github.io/
+bug-reports:    https://github.com/hspec/hspec/issues
+maintainer:     Simon Hengel <sol@typeful.net>
+copyright:      (c) 2011-2019 Simon Hengel,
+                (c) 2011-2012 Trystan Spangler,
+                (c) 2011 Greg Weber
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
 extra-source-files:
     CHANGES.markdown
 
@@ -40,15 +40,6 @@ source-repository head
   location: https://github.com/hspec/hspec
 
 library
-  ghc-options: -Wall
-  hs-source-dirs:
-      src
-  build-depends:
-      QuickCheck >=2.12
-    , base ==4.*
-    , hspec-core ==2.7.1
-    , hspec-discover ==2.7.1
-    , hspec-expectations ==0.8.2.*
   exposed-modules:
       Test.Hspec
       Test.Hspec.Discover
@@ -57,4 +48,13 @@ library
       Test.Hspec.Runner
   other-modules:
       Paths_hspec
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      QuickCheck >=2.12
+    , base ==4.*
+    , hspec-core ==2.7.1
+    , hspec-discover ==2.7.1
+    , hspec-expectations ==0.8.2.*
   default-language: Haskell2010

--- a/src/Test/Hspec/Discover.hs
+++ b/src/Test/Hspec/Discover.hs
@@ -17,18 +17,9 @@ import           Test.Hspec.Core.Spec
 import           Test.Hspec.Core.Runner
 import           Test.Hspec.Formatters
 
-class IsFormatter a where
-  toFormatter :: a -> IO Formatter
-
-instance IsFormatter (IO Formatter) where
-  toFormatter = id
-
-instance IsFormatter Formatter where
-  toFormatter = return
-
 hspecWithFormatter :: IsFormatter a => a -> Spec -> IO ()
 hspecWithFormatter formatter spec = do
-  f <- toFormatter formatter
+  let f = flip toFormatter formatter
   hspecWith defaultConfig {configFormatter = Just f} spec
 
 postProcessSpec :: FilePath -> Spec -> Spec

--- a/src/Test/Hspec/Discover.hs
+++ b/src/Test/Hspec/Discover.hs
@@ -19,7 +19,7 @@ import           Test.Hspec.Formatters
 
 hspecWithFormatter :: IsFormatter a => a -> Spec -> IO ()
 hspecWithFormatter formatter spec = do
-  let f = flip toFormatter formatter
+  let f = toFormatter formatter
   hspecWith defaultConfig {configFormatter = Just f} spec
 
 postProcessSpec :: FilePath -> Spec -> Spec


### PR DESCRIPTION
## Changes

1. Lower level `Format` type is now the api for formatters
2. Asynchronous formatting is supported
3. A new `CustomFormatters` variation of the top level `hspec` allows registering custom formatters for selection from the CLI.

## Tests

All the existing tests pass, and there are some new tests for asynchronous formatting. No new tests for the `CustomFormatters` variations yet.

