### PR TITLE
Interrupt diff calculation after two seconds (see #415)

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,6 @@
+## Next
+  - Interrupt diff calculation if it takes longer than two seconds (see #415)
+
 ## Changes in 2.7.1
   - Add compatibility with QuickCheck 2.13.1 (see #410)
 

--- a/hspec-core/src/Test/Hspec/Core/Clock.hs
+++ b/hspec-core/src/Test/Hspec/Core/Clock.hs
@@ -5,11 +5,13 @@ module Test.Hspec.Core.Clock (
 , getMonotonicTime
 , measure
 , sleep
+, timeout
 ) where
 
 import           Text.Printf
 import           System.Clock
 import           Control.Concurrent
+import qualified System.Timeout as System
 
 newtype Seconds = Seconds Double
   deriving (Eq, Show, Num, Fractional, PrintfArg)
@@ -31,3 +33,6 @@ measure action = do
 
 sleep :: Seconds -> IO ()
 sleep = threadDelay . toMicroseconds
+
+timeout :: Seconds -> IO a -> IO (Maybe a)
+timeout = System.timeout . toMicroseconds

--- a/hspec-core/test/Helper.hs
+++ b/hspec-core/test/Helper.hs
@@ -36,7 +36,6 @@ import           System.Environment (withArgs, getEnvironment)
 import           System.Exit
 import qualified Control.Exception as E
 import           Control.Exception
-import qualified System.Timeout as System
 import           System.IO.Silently
 import           System.SetEnv
 import           System.Directory
@@ -94,9 +93,6 @@ defaultParams = H.defaultParams {H.paramsQuickCheckArgs = stdArgs {replay = Just
 
 noOpProgressCallback :: H.ProgressCallback
 noOpProgressCallback _ = return ()
-
-timeout :: Seconds -> IO a -> IO (Maybe a)
-timeout = System.timeout . toMicroseconds
 
 shouldUseArgs :: HasCallStack => [String] -> (Args -> Bool) -> Expectation
 shouldUseArgs args p = do


### PR DESCRIPTION
@nh2 what do you think about thin change?  Do you think 2 seconds is appropriate?  Is it crucial to print a warning, e.g. "diff calculation took longer than 2 seconds and was interrupted; not showing diff".

This seems to work well within ghci, but not sure about compiled test suites.  I see a chance that `timeout` won't work reliably if you hog a CPU, but I haven't tried.