### PR TITLE
toNanoSpec used is since clock-0.7.1

### DIFF
--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -39,7 +39,7 @@ library
     , array
     , base >=4.5.0.0 && <5
     , call-stack
-    , clock
+    , clock >=0.7.1
     , deepseq
     , directory
     , filepath


### PR DESCRIPTION
Fixes errors like:

```
[ 4 of 27] Compiling Test.Hspec.Core.Clock ( src/Test/Hspec/Core/Clock.hs, /code/mess/hspec-core/hspec-core-2.7.1/.dist-newstyle-trustee/9966c390b1d53c3e56aefdd15f8e77433c7d7a64c5655b25711340a8dfd1696fdb6f15a47279f5e81d4d7d9d639ba58fbdb78eb370323e31441b7d61410cdc3e/build/x86_64-linux/ghc-8.8.1/hspec-core-2.7.1/noopt/build/Test/Hspec/Core/Clock.o )


src/Test/Hspec/Core/Clock.hs:23:37: error:
    Variable not in scope: toNanoSecs :: TimeSpec -> Integer
   |
23 |   return $ Seconds ((fromIntegral . toNanoSecs $ t) / 1000000000)
   |                                     ^^^^^^^^^^
```

---

I made revisions for affected `hspec-core` versions on Hackage. There doesn't seem to be other lower-bound issues.