### PR TITLE
Update docs - module name should be consistent

### DIFF
--- a/doc/hspec-discover.md
+++ b/doc/hspec-discover.md
@@ -85,7 +85,7 @@ default formatter:
 
 ```haskell
 -- file test/Spec.hs
-{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Main #-}
 ```
 
 ```haskell


### PR DESCRIPTION
Module name passed to hspec-discover should be the same as the one in `Main.hs` file, apparently.