### PR TITLE
fix link

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Formatters.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters.hs
@@ -3,7 +3,7 @@
 -- Stability: experimental
 --
 -- This module contains formatters that can be used with
--- `Test.Hspec.Runner.hspecWith`.
+-- `Test.Hspec.Core.Runner.hspecWith`.
 module Test.Hspec.Core.Formatters (
 
 -- * Formatters


### PR DESCRIPTION
Noticed that the link to `hspecWith` is broken in the [doc](http://hackage.haskell.org/package/hspec-core-2.7.4/docs/Test-Hspec-Core-Formatters.html#t:Formatter)