### PR TITLE
Add beforeAllWith

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist/
+dist-newstyle/
+/cabal.project.local

--- a/hspec-core/src/Test/Hspec/Core/Hooks.hs
+++ b/hspec-core/src/Test/Hspec/Core/Hooks.hs
@@ -5,6 +5,7 @@ module Test.Hspec.Core.Hooks (
 , beforeWith
 , beforeAll
 , beforeAll_
+, beforeAllWith
 , after
 , after_
 , afterAll
@@ -44,6 +45,12 @@ beforeAll_ :: IO () -> SpecWith a -> SpecWith a
 beforeAll_ action spec = do
   mvar <- runIO (newMVar Empty)
   before_ (memoize mvar action) spec
+
+-- | Run a custom action with an argument before the first spec item.
+beforeAllWith :: (b -> IO a) -> SpecWith a -> SpecWith b
+beforeAllWith action spec = do
+  mvar <- runIO (newMVar Empty)
+  beforeWith (memoize mvar . action) spec
 
 data Memoized a =
     Empty


### PR DESCRIPTION
I can see there have been several attempts to add a `beforeAllWith` hook in the past, but I'd like to revisit the question.

My use case is as follows:

I'm writing a suite for one part of a larger application. All of the existing tests are passed a test environment via `beforeAll`, and my suite needs to be combined with the other suites to form the top-level suite. However, the part of the application I'm testing has some different characteristics from the rest of the application and I don't want to pollute the main test environment with things that are specific to just one suite. I'd therefore like to wrap my suite with a `beforeAllWith` that in turn wraps the main test environment with a more specific one that includes some extra resources.

I want the entire test app to look like this:

```haskell
main :: IO ()
main = hspec $
  beforeAll mkMainEnv $ do
    describe "Part 1"
      part1suite
    describe "Part 2"
      part2suite
    describe "Special Part"
     specialSuite

newtype MainEnv = MainEnv
  { meSomeField :: Int
  }

mkMainEnv :: IO MainEnv
mkMainEnv = pure $ MainEnv 23

part1suite :: SpecWith MainEnv
part1suite = it "part1" $ \_me -> mempty :: IO ()

part2suite :: SpecWith MainEnv
part2suite = it "part2" $ \_me -> mempty :: IO ()

specialSuite :: SpecWith MainEnv
specialSuite =
  beforeAllWith mkSpecialEnv $ do
    it "does something" $ \env -> do
      doStuff env

data SpecialEnv = SpecialEnv
  { seMainEnv :: MainEnv
  , seOtherField :: String
  }

mkSpecialEnv :: MainEnv -> IO SpecialEnv
mkSpecialEnv me = pure $ SpecialEnv me "foo"

doStuff :: SpecialEnv -> IO ()
doStuff _se = pure ()
```

Without `beforeAllWith` this is impossible, because `beforeAll` returns `Spec` not `SpecWith MainEnv`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hspec/hspec/447)
<!-- Reviewable:end -->
