### PR TITLE
Update doc, the runtime told me to use -N instead of -j

### DIFF
--- a/doc/parallel-spec-execution.md
+++ b/doc/parallel-spec-execution.md
@@ -47,4 +47,5 @@ application's main thread.
 By default, the number of threads available for parallel execution is equal to
 the number of processors available to the process, as determined by
 `+RTS -N`.  A different number (higher or lower) can be specified using the
-`-j` option.  Note that this number is in addition to the main thread.
+`-Nx` option, where `x` is the number.
+Note that this number is in addition to the main thread.


### PR DESCRIPTION
This didn't work for me:

```
✦ ❯ ./result/bin/somebin-test +RTS -N -j4 -RTS
```

This did:

```
✦ ❯ ./result/bin/somebin-test +RTS -N4 -RTS
```

Perhaps I'm wrong but I think the -j option is gone now?