### PR TITLE
docs: Clarify that `-j` is an Hspec option (as opposed to an RTS option)

### DIFF
--- a/doc/parallel-spec-execution.md
+++ b/doc/parallel-spec-execution.md
@@ -46,5 +46,6 @@ application's main thread.
 
 By default, the number of threads available for parallel execution is equal to
 the number of processors available to the process, as determined by
-`+RTS -N`.  A different number (higher or lower) can be specified using the
-`-j` option.  Note that this number is in addition to the main thread.
+`+RTS -N`.  A different number (higher or lower) can be specified with
+[Hspec's `-j` option](options.html).  Note that this number is in
+addition to the main thread.


### PR DESCRIPTION
(fixes #450)