### PR TITLE
Use `shouldBe` instead of == in property test docs.

### DIFF
--- a/doc/quickcheck.md
+++ b/doc/quickcheck.md
@@ -11,7 +11,7 @@ turn anything that is a member of the {{'Testable'|id}} class into a
 ```hspec
 describe "read" $ do
   it "is inverse to show" $ property $
-    \x -> (read . show) x == (x :: Int)
+    \x -> (read . show) x `shouldBe` (x :: Int)
 ```
 
 {% example QuickCheck.hs %}
@@ -26,5 +26,5 @@ import Test.Hspec.Core.QuickCheck (modifyMaxSuccess)
 
 describe "read" $ do
   modifyMaxSuccess (const 1000) $ it "is inverse to show" $ property $
-    \x -> (read . show) x == (x :: Int)
+    \x -> (read . show) x `shouldBe` (x :: Int)
 ```


### PR DESCRIPTION
If a test fails, this will show "expected ... but got ..." instead of just the value generated by QuickCheck, which is 1000x more useful.