### PR TITLE
Call exampleProgress even when running with --no-color

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Formatters/Monad.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/Monad.hs
@@ -56,11 +56,10 @@ data Formatter = Formatter {
 -- | evaluated before each test group
 , exampleGroupStarted :: [String] -> String -> FormatM ()
 
+-- | evaluated after each test group
 , exampleGroupDone :: FormatM ()
 
 -- | used to notify the progress of the currently evaluated example
---
--- /Note/: This is only called when interactive/color mode.
 , exampleProgress :: Path -> Progress -> FormatM ()
 
 -- | evaluated after each successful example


### PR DESCRIPTION
Output is now instead suppressed by writeTransient when running with
--no-color.