### PR TITLE
Add getFinalCount to Formatter API

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -3,6 +3,7 @@
   - Add location information for failing afterAll-hooks
   - Remove `--verbose` option (this has been a noop since at least 2013)
   - Remove `--out` option (use shell output redirection instead)
+  - Add `getFinalCount` to `Formatter` API
 
 ## Changes in 2.7.10
   - Add a new formatter (can be used with `--format checks`)

--- a/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
@@ -66,6 +66,7 @@ interpret = interpretWith Environment {
   environmentGetSuccessCount = getSuccessCount
 , environmentGetPendingCount = getPendingCount
 , environmentGetFailMessages = getFailMessages
+, environmentGetFinalCount = getFinalCount
 , environmentUsedSeed = usedSeed
 , environmentPrintTimes = gets (formatConfigPrintTimes . stateConfig)
 , environmentGetCPUTime = getCPUTime
@@ -100,6 +101,8 @@ data FormatConfig = FormatConfig {
 , formatConfigHtmlOutput :: Bool
 , formatConfigPrintCpuTime :: Bool
 , formatConfigUsedSeed :: Integer
+, formatConfigFinalCount :: !Int
+  -- ^ this field is strict to prevent holding an extra reference to the spec
 } deriving (Eq, Show)
 
 data FormatterState = FormatterState {
@@ -157,6 +160,11 @@ addFailMessage loc p m = modify $ \s -> s {stateFailMessages = FailureRecord loc
 -- | Get the list of accumulated failure messages.
 getFailMessages :: FormatM [FailureRecord]
 getFailMessages = reverse `fmap` gets stateFailMessages
+
+-- | Get the number of spec items that will have been encountered when this run
+-- completes (if it is not terminated early).
+getFinalCount :: FormatM Int
+getFinalCount = getConfig formatConfigFinalCount
 
 overwriteWith :: String -> String -> String
 overwriteWith old new

--- a/hspec-core/src/Test/Hspec/Core/Formatters/Monad.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/Monad.hs
@@ -13,6 +13,7 @@ module Test.Hspec.Core.Formatters.Monad (
 , getPendingCount
 , getFailCount
 , getTotalCount
+, getFinalCount
 
 , FailureRecord (..)
 , getFailMessages
@@ -92,6 +93,7 @@ data FormatF next =
     GetSuccessCount (Int -> next)
   | GetPendingCount (Int -> next)
   | GetFailMessages ([FailureRecord] -> next)
+  | GetFinalCount (Int -> next)
   | UsedSeed (Integer -> next)
   | PrintTimes (Bool -> next)
   | GetCPUTime (Maybe Seconds -> next)
@@ -112,6 +114,7 @@ instance Functor FormatF where -- deriving this instance would require GHC >= 7.
     GetSuccessCount next -> GetSuccessCount (fmap f next)
     GetPendingCount next -> GetPendingCount (fmap f next)
     GetFailMessages next -> GetFailMessages (fmap f next)
+    GetFinalCount next -> GetFinalCount (fmap f next)
     UsedSeed next -> UsedSeed (fmap f next)
     PrintTimes next -> PrintTimes (fmap f next)
     GetCPUTime next -> GetCPUTime (fmap f next)
@@ -136,6 +139,7 @@ data Environment m = Environment {
   environmentGetSuccessCount :: m Int
 , environmentGetPendingCount :: m Int
 , environmentGetFailMessages :: m [FailureRecord]
+, environmentGetFinalCount :: m Int
 , environmentUsedSeed :: m Integer
 , environmentPrintTimes :: m Bool
 , environmentGetCPUTime :: m (Maybe Seconds)
@@ -162,6 +166,7 @@ interpretWith Environment{..} = go
         GetSuccessCount next -> environmentGetSuccessCount >>= go . next
         GetPendingCount next -> environmentGetPendingCount >>= go . next
         GetFailMessages next -> environmentGetFailMessages >>= go . next
+        GetFinalCount next -> environmentGetFinalCount >>= go . next
         UsedSeed next -> environmentUsedSeed >>= go . next
         PrintTimes next -> environmentPrintTimes >>= go . next
         GetCPUTime next -> environmentGetCPUTime >>= go . next
@@ -192,6 +197,11 @@ getFailCount = length <$> getFailMessages
 -- | Get the total number of examples encountered so far.
 getTotalCount :: FormatM Int
 getTotalCount = sum <$> sequence [getSuccessCount, getFailCount, getPendingCount]
+
+-- | Get the number of spec items that will have been encountered when this run
+-- completes (if it is not terminated early).
+getFinalCount :: FormatM Int
+getFinalCount = liftF (GetFinalCount id)
 
 -- | Get the list of accumulated failure messages.
 getFailMessages :: FormatM [FailureRecord]

--- a/hspec-core/src/Test/Hspec/Core/Runner.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner.hs
@@ -201,6 +201,7 @@ runSpec_ config spec = do
   let formatter = fromMaybe specdoc (configFormatter config)
       seed = (fromJust . configQuickCheckSeed) config
       qcArgs = configQuickCheckArgs config
+      numberOfItems = countSpecItems filteredSpec
 
   concurrentJobs <- case configConcurrentJobs config of
     Nothing -> getDefaultConcurrentJobs
@@ -218,6 +219,7 @@ runSpec_ config spec = do
       , formatConfigHtmlOutput = configHtmlOutput config
       , formatConfigPrintCpuTime = configPrintCpuTime config
       , formatConfigUsedSeed =  seed
+      , formatConfigFinalCount = numberOfItems
       }
       evalConfig = EvalConfig {
         evalConfigFormat = formatterToFormat formatter formatConfig
@@ -309,3 +311,6 @@ randomizeForest :: Integer -> [Tree c a] -> [Tree c a]
 randomizeForest seed t = runST $ do
   ref <- newSTRef (mkStdGen $ fromIntegral seed)
   shuffleForest ref t
+
+countSpecItems :: [EvalTree] -> Int
+countSpecItems = getSum . foldMap (foldMap . const $ Sum 1)

--- a/hspec-core/test/Test/Hspec/Core/FormattersSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/FormattersSpec.hs
@@ -65,6 +65,7 @@ environment = Environment {
   environmentGetSuccessCount = return 0
 , environmentGetPendingCount = return 0
 , environmentGetFailMessages = return []
+, environmentGetFinalCount = return 0
 , environmentUsedSeed = return 0
 , environmentGetCPUTime = return Nothing
 , environmentGetRealTime = return 0
@@ -279,6 +280,14 @@ spec = do
 
     context "same as failed_examples" $ do
       failed_examplesSpec formatter
+
+  describe "additional formatter features" $ do
+    describe "getFinalCount" $ do
+      let formatter = H.silent {H.footerFormatter = fmap show H.getFinalCount >>= H.writeLine}
+          runSpec = captureLines . H.hspecWithResult H.defaultConfig {H.configFormatter = Just formatter}
+      it "counts examples" $ do
+        result:_ <- runSpec testSpec
+        result `shouldBe` "6"
 
 failed_examplesSpec :: H.Formatter -> Spec
 failed_examplesSpec formatter = do


### PR DESCRIPTION
getFinalCount returns the final number of examples that will have been
encountered in this run. (The name is slightly non-obvious, but
getTotalCount was already taken.) This allows formatters to report
total run progress as a ratio or a percentage, or display a filling
progress bar, etc.