### PR TITLE
Use -XNoImplicitPrelude for hspec-discover generated test drivers

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -3,6 +3,7 @@
     `--format specdoc`)
   - Add --times to print times for individual spec items
   - Add location information for failing afterAll-hooks
+  - Use `-XNoImplicitPrelude` for `hspec-discover` generated test drivers
   - Cleanup Formatter API:
     - Merge `exampleSucceeded`, `examplePending` and `exampleFailed`.  The new
       field is called `formatterItemDone`.

--- a/hspec-discover/src/Test/Hspec/Discover/Run.hs
+++ b/hspec-discover/src/Test/Hspec/Discover/Run.hs
@@ -59,6 +59,7 @@ run args_ = do
 mkSpecModule :: FilePath -> Config -> [Spec] -> String
 mkSpecModule src conf nodes =
   ( "{-# LINE 1 " . shows src . " #-}\n"
+  . showString "{-# LANGUAGE NoImplicitPrelude #-}\n"
   . showString "{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}\n"
   . showString ("module " ++ moduleName src conf ++" where\n")
   . importList nodes

--- a/hspec-discover/test/Test/Hspec/Discover/RunSpec.hs
+++ b/hspec-discover/test/Test/Hspec/Discover/RunSpec.hs
@@ -28,6 +28,7 @@ spec = do
       run ["test-data/nested-spec/Spec.hs", "", f]
       readFile f `shouldReturn` unlines [
           "{-# LINE 1 \"test-data/nested-spec/Spec.hs\" #-}"
+        , "{-# LANGUAGE NoImplicitPrelude #-}"
         , "{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}"
         , "module Main where"
         , "import qualified Foo.Bar.BazSpec"
@@ -48,6 +49,7 @@ spec = do
       run ["test-data/empty-dir/Spec.hs", "", f]
       readFile f `shouldReturn` unlines [
           "{-# LINE 1 \"test-data/empty-dir/Spec.hs\" #-}"
+        , "{-# LANGUAGE NoImplicitPrelude #-}"
         , "{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}"
         , "module Main where"
         , "import Test.Hspec.Discover"

--- a/src/Test/Hspec/Discover.hs
+++ b/src/Test/Hspec/Discover.hs
@@ -11,8 +11,6 @@ module Test.Hspec.Discover {-# WARNING
 , module Prelude
 ) where
 
-import           Prelude hiding (mapM)
-
 import           Test.Hspec.Core.Spec
 import           Test.Hspec.Core.Runner
 import           Test.Hspec.Formatters


### PR DESCRIPTION
(close #500)