### PR TITLE
hspec-discover: Deprecate `--no-main` and `--formatter`

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -16,6 +16,8 @@
   - Remove `--verbose` option (this has been a noop since at least 2013)
   - Remove `--out` option (use shell output redirection instead)
   - Add `getFinalCount` to `Formatter` API
+  - hspec-discover: Deprecate `--no-main` and `--formatter` (use
+    `--module-name` instead) (#196)
 
 ## Changes in 2.7.10
   - Add a new formatter (can be used with `--format checks`)

--- a/hspec-discover/src/Test/Hspec/Discover/Run.hs
+++ b/hspec-discover/src/Test/Hspec/Discover/Run.hs
@@ -48,7 +48,9 @@ run args_ = do
         hPutStrLn stderr err
         exitFailure
       Right conf -> do
-        when (configNested conf) (hPutStrLn stderr "hspec-discover: WARNING - The `--nested' option is deprecated and will be removed in a future release!")
+        when (configNested conf)             (hPutStrLn stderr "hspec-discover: WARNING - The `--nested' option is deprecated and will be removed in a future release!")
+        when (configNoMain conf)             (hPutStrLn stderr "hspec-discover: WARNING - The `--no-main' option is deprecated and will be removed in a future release!")
+        when (isJust $ configFormatter conf) (hPutStrLn stderr "hspec-discover: WARNING - The `--formatter' option is deprecated and will be removed in a future release!")
         specs <- findSpecs src
         writeFile dst (mkSpecModule src conf specs)
     _ -> do


### PR DESCRIPTION
(close #196)