### PR TITLE
changed: show -> ushow closed #384

### DIFF
--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.5.
 --
 -- see: https://github.com/sol/hpack
 
@@ -50,6 +50,7 @@ library
     , stm >=2.2
     , tf-random
     , transformers >=0.2.2.0
+    , unicode-show
   exposed-modules:
       Test.Hspec.Core.Spec
       Test.Hspec.Core.Hooks
@@ -116,6 +117,7 @@ test-suite spec
     , temporary
     , tf-random
     , transformers >=0.2.2.0
+    , unicode-show
   build-tool-depends:
       hspec-meta:hspec-meta-discover
   other-modules:

--- a/hspec-core/package.yaml
+++ b/hspec-core/package.yaml
@@ -37,6 +37,7 @@ dependencies:
   - call-stack
   - directory
   - filepath
+  - unicode-show
 
   - stm >= 2.2 # for asyc
   - array # for Diff

--- a/hspec-core/src/Test/Hspec/Core/Formatters/V1.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/V1.hs
@@ -326,7 +326,7 @@ defaultFailedFormatter = do
         Error _ e -> withFailColor . indent $ (("uncaught exception: " ++) . formatException) e
 
       writeLine ""
-      writeLine ("  To rerun use: --match " ++ show (joinPath path))
+      writeLine ("  To rerun use: --match " ++ ['"'] ++ joinPath path ++ ['"'])
       where
         indentation = "       "
         indent message = do

--- a/hspec-core/src/Test/Hspec/Core/Formatters/V1.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/V1.hs
@@ -67,6 +67,7 @@ import           Test.Hspec.Core.Util
 import           Test.Hspec.Core.Clock
 import           Test.Hspec.Core.Spec (Location(..))
 import           Text.Printf
+import           Text.Show.Unicode (ushow)
 import           Control.Monad.IO.Class
 import           Control.Exception
 
@@ -203,8 +204,8 @@ checks = specdoc {
         writeLine $ indentationFor ("" : nesting) ++ s
 
     formatProgress (current, total)
-      | total == 0 = show current
-      | otherwise  = show current ++ "/" ++ show total
+      | total == 0 = ushow current
+      | otherwise  = ushow current ++ "/" ++ ushow total
 
 specdoc :: Formatter
 specdoc = silent {
@@ -225,7 +226,7 @@ specdoc = silent {
 
 , exampleFailed = \(nesting, requirement) info _ -> withFailColor $ do
     n <- getFailCount
-    writeLine $ indentationFor nesting ++ requirement ++ " FAILED [" ++ show n ++ "]"
+    writeLine $ indentationFor nesting ++ requirement ++ " FAILED [" ++ ushow n ++ "]"
     forM_ (lines info) $ \ s ->
       writeLine $ indentationFor ("" : nesting) ++ s
 
@@ -241,8 +242,8 @@ specdoc = silent {
 } where
     indentationFor nesting = replicate (length nesting * 2) ' '
     formatProgress (current, total)
-      | total == 0 = show current
-      | otherwise  = show current ++ "/" ++ show total
+      | total == 0 = ushow current
+      | otherwise  = ushow current ++ "/" ++ ushow total
 
 
 progress :: Formatter
@@ -275,14 +276,14 @@ defaultFailedFormatter = do
       formatFailure x
       writeLine ""
 
-    write "Randomized with seed " >> usedSeed >>= writeLine . show
+    write "Randomized with seed " >> usedSeed >>= writeLine . ushow
     writeLine ""
   where
     formatFailure :: (Int, FailureRecord) -> FormatM ()
     formatFailure (n, FailureRecord mLoc path reason) = do
       forM_ mLoc $ \loc -> do
         withInfoColor $ writeLine (formatLoc loc)
-      write ("  " ++ show n ++ ") ")
+      write ("  " ++ ushow n ++ ") ")
       writeLine (formatRequirement path)
       case reason of
         NoReason -> return ()
@@ -326,13 +327,13 @@ defaultFailedFormatter = do
         Error _ e -> withFailColor . indent $ (("uncaught exception: " ++) . formatException) e
 
       writeLine ""
-      writeLine ("  To rerun use: --match " ++ show (joinPath path))
+      writeLine ("  To rerun use: --match " ++ ushow (joinPath path))
       where
         indentation = "       "
         indent message = do
           forM_ (lines message) $ \line -> do
             writeLine (indentation ++ line)
-        formatLoc (Location file line column) = "  " ++ file ++ ":" ++ show line ++ ":" ++ show column ++ ": "
+        formatLoc (Location file line column) = "  " ++ file ++ ":" ++ ushow line ++ ":" ++ ushow column ++ ": "
 
 defaultFooter :: FormatM ()
 defaultFooter = do
@@ -349,7 +350,7 @@ defaultFooter = do
     output =
          pluralize total   "example"
       ++ ", " ++ pluralize fails "failure"
-      ++ if pending == 0 then "" else ", " ++ show pending ++ " pending"
+      ++ if pending == 0 then "" else ", " ++ ushow pending ++ " pending"
     c | fails /= 0   = withFailColor
       | pending /= 0 = withPendingColor
       | otherwise    = withSuccessColor

--- a/hspec-core/src/Test/Hspec/Core/Formatters/V1.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/V1.hs
@@ -326,7 +326,7 @@ defaultFailedFormatter = do
         Error _ e -> withFailColor . indent $ (("uncaught exception: " ++) . formatException) e
 
       writeLine ""
-      writeLine ("  To rerun use: --match " ++ ['"'] ++ joinPath path ++ ['"'])
+      writeLine ("  To rerun use: --match " ++ show (joinPath path))
       where
         indentation = "       "
         indent message = do

--- a/hspec-core/src/Test/Hspec/Core/Formatters/V2.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/V2.hs
@@ -71,6 +71,7 @@ import           Test.Hspec.Core.Util
 import           Test.Hspec.Core.Clock
 import           Test.Hspec.Core.Spec (Location(..))
 import           Text.Printf
+import           Text.Show.Unicode (ushow)
 import           Control.Monad.IO.Class
 import           Control.Exception
 
@@ -162,11 +163,11 @@ checks = specdoc {
 
         times
           | dt == 0 = ""
-          | otherwise = " (" ++ show dt ++ "ms)"
+          | otherwise = " (" ++ ushow dt ++ "ms)"
 
     formatProgress (current, total)
-      | total == 0 = show current
-      | otherwise  = show current ++ "/" ++ show total
+      | total == 0 = ushow current
+      | otherwise  = ushow current ++ "/" ++ ushow total
 
 specdoc :: Formatter
 specdoc = silent {
@@ -192,7 +193,7 @@ specdoc = silent {
         writeLine $ indentationFor ("" : nesting) ++ "# PENDING: " ++ fromMaybe "No reason given" reason
       Failure {} -> withFailColor $ do
         n <- getFailCount
-        writeResult nesting (requirement ++ " FAILED [" ++ show n ++ "]") duration info
+        writeResult nesting (requirement ++ " FAILED [" ++ ushow n ++ "]") duration info
 
 , formatterDone = defaultFailedFormatter >> defaultFooter
 } where
@@ -209,11 +210,11 @@ specdoc = silent {
 
         times
           | dt == 0 = ""
-          | otherwise = " (" ++ show dt ++ "ms)"
+          | otherwise = " (" ++ ushow dt ++ "ms)"
 
     formatProgress (current, total)
-      | total == 0 = show current
-      | otherwise  = show current ++ "/" ++ show total
+      | total == 0 = ushow current
+      | otherwise  = ushow current ++ "/" ++ ushow total
 
 progress :: Formatter
 progress = failed_examples {
@@ -242,14 +243,14 @@ defaultFailedFormatter = do
       formatFailure x
       writeLine ""
 
-    write "Randomized with seed " >> usedSeed >>= writeLine . show
+    write "Randomized with seed " >> usedSeed >>= writeLine . ushow
     writeLine ""
   where
     formatFailure :: (Int, FailureRecord) -> FormatM ()
     formatFailure (n, FailureRecord mLoc path reason) = do
       forM_ mLoc $ \loc -> do
         withInfoColor $ writeLine ("  " ++ formatLocation loc)
-      write ("  " ++ show n ++ ") ")
+      write ("  " ++ ushow n ++ ") ")
       writeLine (formatRequirement path)
       case reason of
         NoReason -> return ()
@@ -293,7 +294,7 @@ defaultFailedFormatter = do
         Error _ e -> withFailColor . indent $ (("uncaught exception: " ++) . formatException) e
 
       writeLine ""
-      writeLine ("  To rerun use: --match " ++ show (joinPath path))
+      writeLine ("  To rerun use: --match " ++ ushow (joinPath path))
       where
         indentation = "       "
         indent message = do
@@ -315,11 +316,11 @@ defaultFooter = do
     output =
          pluralize total   "example"
       ++ ", " ++ pluralize fails "failure"
-      ++ if pending == 0 then "" else ", " ++ show pending ++ " pending"
+      ++ if pending == 0 then "" else ", " ++ ushow pending ++ " pending"
     c | fails /= 0   = withFailColor
       | pending /= 0 = withPendingColor
       | otherwise    = withSuccessColor
   c $ writeLine output
 
 formatLocation :: Location -> String
-formatLocation (Location file line column) = file ++ ":" ++ show line ++ ":" ++ show column ++ ": "
+formatLocation (Location file line column) = file ++ ":" ++ ushow line ++ ":" ++ ushow column ++ ": "

--- a/hspec-core/src/Test/Hspec/Core/Formatters/V2.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/V2.hs
@@ -293,7 +293,7 @@ defaultFailedFormatter = do
         Error _ e -> withFailColor . indent $ (("uncaught exception: " ++) . formatException) e
 
       writeLine ""
-      writeLine ("  To rerun use: --match " ++ show (joinPath path))
+      writeLine ("  To rerun use: --match " ++ ['"'] ++ joinPath path ++ ['"'])
       where
         indentation = "       "
         indent message = do

--- a/hspec-core/src/Test/Hspec/Core/Formatters/V2.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/V2.hs
@@ -293,7 +293,7 @@ defaultFailedFormatter = do
         Error _ e -> withFailColor . indent $ (("uncaught exception: " ++) . formatException) e
 
       writeLine ""
-      writeLine ("  To rerun use: --match " ++ ['"'] ++ joinPath path ++ ['"'])
+      writeLine ("  To rerun use: --match " ++ show (joinPath path))
       where
         indentation = "       "
         indent message = do


### PR DESCRIPTION
relation: [Human-readable output of unicode characters in expectation results · Issue #384 · hspec/hspec](https://github.com/hspec/hspec/issues/384)

Show promotes string escaping, so it is not used in unnecessary parts.

This will result in the following display improvements.

> To rerun use: --match "/FooBar/\30333\12356\29356\12364\36208\12427\12290/"

to

> To rerun use: --match "/FooBar/白い犬が走る。/"