### PR TITLE
Do not depend on clock

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,6 @@
+## Changes in next
+  - Do not depend on `clock`
+
 ## Changes in 2.10.1
   - Support for GHC 9.4.1
   - Generated modules now include an export list

--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -40,7 +40,6 @@ library
     , array
     , base >=4.5.0.0 && <5
     , call-stack >=0.2.0
-    , clock >=0.7.1
     , deepseq
     , directory
     , filepath
@@ -49,6 +48,7 @@ library
     , random
     , setenv
     , tf-random
+    , time
     , transformers >=0.2.2.0
   exposed-modules:
       Test.Hspec.Core.Spec
@@ -125,7 +125,6 @@ test-suite spec
     , base >=4.5.0.0 && <5
     , base-orphans
     , call-stack >=0.2.0
-    , clock >=0.7.1
     , deepseq
     , directory
     , filepath
@@ -138,6 +137,7 @@ test-suite spec
     , silently >=1.2.4
     , temporary
     , tf-random
+    , time
     , transformers >=0.2.2.0
   build-tool-depends:
       hspec-meta:hspec-meta-discover

--- a/hspec-core/package.yaml
+++ b/hspec-core/package.yaml
@@ -29,7 +29,7 @@ dependencies:
   - tf-random
   - setenv
   - ansi-terminal >= 0.6.2
-  - clock >= 0.7.1
+  - time
   - transformers >= 0.2.2.0
   - deepseq
   - HUnit == 1.6.*


### PR DESCRIPTION
This is trading correctness for fewer dependencies.  One immediate
benefit of this change is that we will get GHC 9.2.1 support right now.

The new code uses getCurrentTime, which is not monotonic.  As a
consequence the new behavior is less accurate when:

- A test run spans a leap second
- The system clock is adjusted during a test run

Both of these events are reasonably rare, so I hope this is the right
thing to do.