### PR TITLE
Rename configFastFail to configFailFast

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Config/Definition.hs
+++ b/hspec-core/src/Test/Hspec/Core/Config/Definition.hs
@@ -38,7 +38,7 @@ data Config = Config {
 , configFailOnFocused :: Bool
 , configPrintSlowItems :: Maybe Int
 , configPrintCpuTime :: Bool
-, configFastFail :: Bool
+, configFailFast :: Bool
 , configRandomize :: Bool
 , configFailureReport :: Maybe FilePath
 , configRerun :: Bool
@@ -72,7 +72,7 @@ defaultConfig = Config {
 , configFailOnFocused = False
 , configPrintSlowItems = Nothing
 , configPrintCpuTime = False
-, configFastFail = False
+, configFailFast = False
 , configRandomize = False
 , configFailureReport = Nothing
 , configRerun = False
@@ -214,7 +214,7 @@ runnerOptions = [
     mkFlag "dry-run" setDryRun "pretend that everything passed; don't verify anything"
   , mkFlag "focused-only" setFocusedOnly "do not run anything, unless there are focused spec items"
   , mkFlag "fail-on-focused" setFailOnFocused "fail on focused spec items"
-  , mkFlag "fail-fast" setFastFail "abort on first failure"
+  , mkFlag "fail-fast" setFailFast "abort on first failure"
   , mkFlag "randomize" setRandomize "randomize execution order"
   , mkOptionNoArg "rerun" (Just 'r') setRerun "rerun all examples that failed in the previous test run (only works in combination with --failure-report or in GHCi)"
   , option "failure-report" (argument "FILE" return setFailureReport) "read/write a failure report for use with --rerun"
@@ -243,8 +243,8 @@ runnerOptions = [
     setFailOnFocused :: Bool -> Config -> Config
     setFailOnFocused value config = config {configFailOnFocused = value}
 
-    setFastFail :: Bool -> Config -> Config
-    setFastFail value config = config {configFastFail = value}
+    setFailFast :: Bool -> Config -> Config
+    setFailFast value config = config {configFailFast = value}
 
     setRandomize :: Bool -> Config -> Config
     setRandomize value config = config {configRandomize = value}

--- a/hspec-core/src/Test/Hspec/Core/Runner.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner.hs
@@ -234,7 +234,7 @@ runSpec_ config spec = do
       evalConfig = EvalConfig {
         evalConfigFormat = format
       , evalConfigConcurrentJobs = concurrentJobs
-      , evalConfigFastFail = configFastFail config
+      , evalConfigFailFast = configFailFast config
       }
     runFormatter evalConfig filteredSpec
 

--- a/hspec-core/src/Test/Hspec/Core/Runner/Eval.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner/Eval.hs
@@ -51,7 +51,7 @@ type MonadIO m = (Monad m, M.MonadIO m)
 data EvalConfig = EvalConfig {
   evalConfigFormat :: Format
 , evalConfigConcurrentJobs :: Int
-, evalConfigFastFail :: Bool
+, evalConfigFailFast :: Bool
 }
 
 data Env = Env {
@@ -210,7 +210,7 @@ replaceMVar mvar p = tryTakeMVar mvar >> putMVar mvar p
 
 run :: [RunningTree IO] -> EvalM ()
 run specs = do
-  fastFail <- asks (evalConfigFastFail . envConfig)
+  fastFail <- asks (evalConfigFailFast . envConfig)
   sequenceActions fastFail (concatMap foldSpec specs)
   where
     foldSpec :: RunningTree IO -> [EvalM ()]

--- a/hspec-core/test/Test/Hspec/Core/HooksSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/HooksSpec.hs
@@ -23,7 +23,7 @@ evalSpec = fmap normalize . (H.specToEvalForest H.defaultConfig >=> runFormatter
     config = EvalConfig {
       evalConfigFormat = \ _ -> return ()
     , evalConfigConcurrentJobs = 1
-    , evalConfigFastFail = False
+    , evalConfigFailFast = False
     }
     normalize = map $ \ (path, item) -> (pathToList path, normalizeItem item)
     normalizeItem item = item {


### PR DESCRIPTION
(so that it matches the command-line flag `--fail-fast`)