### PR TITLE
Revert "hspec-discover: Add support for custom configs"

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,10 +1,9 @@
 ## Changes in next
-  - Use `checks` formatter by default (to restore the old behavior use
-    `--format specdoc`)
   - Allow to extend the list of available formatters for `--format`
-  - Add support for custom configs to `hspec-discover` (via `SpecConfig.hs`)
   - Add `getExpectedTotalCount` to `Test.Hspec.Core.Formatters.V2`
   - Rename `formatConfigItemCount` to `formatConfigExpectedTotalCount`
+  - Use `checks` formatter by default (to restore the old behavior use
+    `--format specdoc`)
 
 ## Changes in 2.8.4
   - Better support for GHC 9.2.1
@@ -13,7 +12,7 @@
 
 ## Changes in 2.8.3
   - Better support for `--color=auto` on Windows
-  - Add support for spec hooks to `hspec-discover` (via `SpecHook.hs`)
+  - Add support for spec hooks to `hspec-discover` (via `SpecHooks.hs`)
   - Propagate exceptions from `Test.Hspec.Core.Format.monadic`
   - Re-export `aroundAll_` from `Test.Hspec`
 

--- a/hspec-discover/integration-test/hspec-discover-integration-tests.cabal
+++ b/hspec-discover/integration-test/hspec-discover-integration-tests.cabal
@@ -144,22 +144,3 @@ test-suite with-spec-hook
       base    == 4.*
     , hspec
   default-language: Haskell2010
-
-test-suite with-config
-  build-tool-depends: hspec-discover:hspec-discover
-  type:
-      exitcode-stdio-1.0
-  ghc-options:
-      -Wall
-  hs-source-dirs:
-      with-config
-  main-is:
-      Spec.hs
-  other-modules:
-      FooSpec
-      SpecConfig
-  build-depends:
-      base    == 4.*
-    , hspec
-    , hspec-core
-  default-language: Haskell2010

--- a/hspec-discover/integration-test/with-config/FooSpec.hs
+++ b/hspec-discover/integration-test/with-config/FooSpec.hs
@@ -1,9 +1,0 @@
-module FooSpec (spec) where
-
-import           Test.Hspec
-
-spec :: Spec
-spec = do
-  describe "reverse" $ do
-    it "reverses a list" $ do
-      reverse [1 :: Int, 2, 3] `shouldBe` [3, 2, 1]

--- a/hspec-discover/integration-test/with-config/Spec.hs
+++ b/hspec-discover/integration-test/with-config/Spec.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/hspec-discover/integration-test/with-config/SpecConfig.hs
+++ b/hspec-discover/integration-test/with-config/SpecConfig.hs
@@ -1,9 +1,0 @@
-module SpecConfig where
-
-import Test.Hspec.Runner
-import Test.Hspec.Core.Formatters.V2
-
-config :: Config -> IO Config
-config c = return c {
-  configFormat = Just $ formatterToFormat progress
-}

--- a/hspec-discover/test/Test/Hspec/Discover/RunSpec.hs
+++ b/hspec-discover/test/Test/Hspec/Discover/RunSpec.hs
@@ -4,6 +4,7 @@ import           Helper
 import           Test.Mockery.Directory
 
 import           Test.Hspec.Discover.Run hiding (Spec)
+import qualified Test.Hspec.Discover.Run as Run
 
 spec :: Spec
 spec = do
@@ -60,32 +61,6 @@ spec = do
           ]
         ]
 
-    it "generates a test driver with config" $ do
-      touch "test/FooSpec.hs"
-      touch "test/Foo/Bar/BazSpec.hs"
-      touch "test/Foo/BarSpec.hs"
-      touch "test/SpecConfig.hs"
-      run ["test/Spec.hs", "", "out"]
-      readFile "out" `shouldReturn` unlines [
-          "{-# LINE 1 \"test/Spec.hs\" #-}"
-        , "{-# LANGUAGE NoImplicitPrelude #-}"
-        , "{-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}"
-        , "module Main where"
-        , "import qualified SpecConfig"
-        , "import qualified FooSpec"
-        , "import qualified Foo.BarSpec"
-        , "import qualified Foo.Bar.BazSpec"
-        , "import Test.Hspec.Discover"
-        , "main :: IO ()"
-        , "main = SpecConfig.config defaultConfig >>= flip hspecWith spec"
-        , "spec :: Spec"
-        , "spec = " ++ unwords [
-               "describe \"Foo\" FooSpec.spec"
-          , ">> describe \"Foo.Bar\" Foo.BarSpec.spec"
-          , ">> describe \"Foo.Bar.Baz\" Foo.Bar.BazSpec.spec"
-          ]
-        ]
-
     it "generates a test driver for an empty directory" $ do
       touch "test/Foo/Bar/Baz/.placeholder"
       run ["test/Spec.hs", "", "out"]
@@ -117,20 +92,27 @@ spec = do
     it "returns the module name of a fully qualified identifier" $ do
       moduleNameFromId "Some.Module.someId" `shouldBe` "Some.Module"
 
+  describe "importList" $ do
+    it "generates imports for a list of specs" $ do
+      importList (Just [Run.Spec "Foo", Run.Spec "Bar"]) "" `shouldBe` unlines [
+          "import qualified FooSpec"
+        , "import qualified BarSpec"
+        ]
+
   describe "discover" $ do
     it "discovers spec files" $ do
       inTempDirectory $ do
         touch "test/Spec.hs"
         touch "test/FooSpec.hs"
         touch "test/BarSpec.hs"
-        discover "test/Spec.hs" `shouldReturn` Just (SpecForest WithoutConfig $ Forest WithoutHook [Leaf "Bar", Leaf "Foo"])
+        discover "test/Spec.hs" `shouldReturn` Just (Forest WithoutHook [Leaf "Bar", Leaf "Foo"])
 
     it "discovers nested spec files" $ do
       inTempDirectory $ do
         touch "test/Spec.hs"
         touch "test/Foo/BarSpec.hs"
         touch "test/Foo/BazSpec.hs"
-        discover "test/Spec.hs" `shouldReturn` Just (SpecForest WithoutConfig $ Forest WithoutHook [Node "Foo" (Forest WithoutHook [Leaf "Bar", Leaf "Baz"])])
+        discover "test/Spec.hs" `shouldReturn` Just (Forest WithoutHook [Node "Foo" (Forest WithoutHook [Leaf "Bar", Leaf "Baz"])])
 
     it "discovers hooks" $ do
       inTempDirectory $ do
@@ -138,7 +120,7 @@ spec = do
         touch "test/FooSpec.hs"
         touch "test/BarSpec.hs"
         touch "test/SpecHook.hs"
-        discover "test/Spec.hs" `shouldReturn` Just (SpecForest WithoutConfig $ Forest WithHook [Leaf "Bar", Leaf "Foo"])
+        discover "test/Spec.hs" `shouldReturn` Just (Forest WithHook [Leaf "Bar", Leaf "Foo"])
 
     it "discovers nested hooks" $ do
       inTempDirectory $ do
@@ -146,15 +128,7 @@ spec = do
         touch "test/Foo/BarSpec.hs"
         touch "test/Foo/BazSpec.hs"
         touch "test/Foo/SpecHook.hs"
-        discover "test/Spec.hs" `shouldReturn` Just (SpecForest WithoutConfig $ Forest WithoutHook [Node "Foo" (Forest WithHook [Leaf "Bar", Leaf "Baz"])])
-
-    it "discovers spec config" $ do
-      inTempDirectory $ do
-        touch "test/Spec.hs"
-        touch "test/FooSpec.hs"
-        touch "test/BarSpec.hs"
-        touch "test/SpecConfig.hs"
-        discover "test/Spec.hs" `shouldReturn` Just (SpecForest WithConfig $ Forest WithoutHook [Leaf "Bar", Leaf "Foo"])
+        discover "test/Spec.hs" `shouldReturn` Just (Forest WithoutHook [Node "Foo" (Forest WithHook [Leaf "Bar", Leaf "Baz"])])
 
     it "ignores invalid module names" $ do
       inTempDirectory $ do

--- a/src/Test/Hspec/Discover.hs
+++ b/src/Test/Hspec/Discover.hs
@@ -4,8 +4,6 @@ module Test.Hspec.Discover {-# WARNING
   #-} (
   Spec
 , hspec
-, hspecWith
-, defaultConfig
 , IsFormatter (..)
 , hspecWithFormatter
 , postProcessSpec


### PR DESCRIPTION
After discussing this with @soenkehahn, I'm inclined to reconsider going with #555 instead.

This reverts commit ec713883740b5134f32b27b7863fe5753f3acbd3 (https://github.com/hspec/hspec/pull/527).