### PR TITLE
Recover unicode from ExpectedButGot (close #384)

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,4 +1,5 @@
 ## Changes in next
+  - Recover unicode from `ExpectedButGot`
   - Preserve unicode in `To rerun use: --match ...` output
 
 ## Changes in 2.9.0

--- a/hspec-core/test/Test/Hspec/Core/Formatters/V2Spec.hs
+++ b/hspec-core/test/Test/Hspec/Core/Formatters/V2Spec.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE DeriveFunctor #-}
 module Test.Hspec.Core.Formatters.V2Spec (spec) where
 
 import           Prelude ()
@@ -173,6 +169,25 @@ spec = do
           ]
 
     describe "formatterDone" $ do
+      it "recovers unicode from ExpectedButGot" $ do
+        formatter <- formatterToFormat progress formatConfig { formatConfigOutputUnicode = True }
+        _ <- formatter .  ItemDone ([], "") . Item Nothing 0 "" $ Failure Nothing $ ExpectedButGot Nothing (show "\955") (show "\956")
+        (fmap normalizeSummary . captureLines) (formatter $ Done []) `shouldReturn` [
+            ""
+          , "Failures:"
+          , ""
+          , "  1) "
+          , "       expected: \"λ\""
+          , "        but got: \"μ\""
+          , ""
+          , "  To rerun use: --match \"//\""
+          , ""
+          , "Randomized with seed 0"
+          , ""
+          , "Finished in 0.0000 seconds"
+          , "1 example, 1 failure"
+          ]
+
       context "when actual/expected contain newlines" $ do
         it "adds indentation" $ do
           formatter <- formatterToFormat progress formatConfig


### PR DESCRIPTION
This turns e.g.

    expected: "\956"
     but got: "\955"

into

    expected: "μ"
     but got: "λ"