### PR TITLE
Text.Show.Unicode: Don't use (Applicative ReadP) (close #576)

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Util.hs
+++ b/hspec-core/src/Test/Hspec/Core/Util.hs
@@ -11,7 +11,7 @@ module Test.Hspec.Core.Util (
 , formatRequirement
 , filterPredicate
 
--- * Working with exception
+-- * Working with exceptions
 , safeTry
 , formatException
 ) where

--- a/hspec-core/vendor/Text/Show/Unicode.hs
+++ b/hspec-core/vendor/Text/Show/Unicode.hs
@@ -50,12 +50,17 @@ import qualified Text.Show.Unicode
 module Text.Show.Unicode (ushow, uprint, urecover, ushowWith, uprintWith, urecoverWith) where
 
 import           Prelude ()
-import           Test.Hspec.Core.Compat hiding (many)
+import           Test.Hspec.Core.Compat hiding (many, (<*>), (*>), (<*))
 
 import           Data.Char                    (isAscii, isPrint)
 import           Text.ParserCombinators.ReadP
 import           Text.Read.Lex                (lexChar)
 import qualified Data.List                     as L
+
+infixl 4 <*
+
+(<*) :: Monad m => m a -> m b -> m a
+(<*) = flip (>>)
 
 -- Represents a replaced character using its literal form and its escaped form.
 type Replacement = (String, String)


### PR DESCRIPTION
(for compatibility with `base-4.5.*`)