### PR TITLE
Assume --color by default when running on GitHub Actions

### DIFF
--- a/hspec-core/test/Spec.hs
+++ b/hspec-core/test/Spec.hs
@@ -4,11 +4,10 @@ import           Prelude ()
 import           Helper
 
 import           Test.Hspec.Meta
-import           System.SetEnv
 import qualified All
 
 spec :: Spec
-spec = beforeAll_ (setEnv "IGNORE_DOT_HSPEC" "yes" >> unsetEnv "HSPEC_OPTIONS") $ afterAll_ (unsetEnv "IGNORE_DOT_HSPEC") All.spec
+spec = aroundAll_ (withEnvironment [("IGNORE_DOT_HSPEC", "yes")]) All.spec
 
 main :: IO ()
 main = hspec spec

--- a/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
@@ -576,15 +576,25 @@ spec = do
         high `shouldBe` j
 
   describe "colorOutputSupported" $ do
-    it "returns False" $ do
-      withEnvironment [] $ do
-        H.colorOutputSupported H.ColorAuto (return False) `shouldReturn` False
+
+    context "without a terminal device" $ do
+
+      let isTerminalDevice = return False
+
+      it "returns False" $ do
+        H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` False
+
+      context "with GITHUB_ACTIONS=true" $ do
+        it "returns True" $ do
+          withEnvironment [("GITHUB_ACTIONS", "true")] $ do
+            H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` True
 
     context "with a terminal device" $ do
+
       let isTerminalDevice = return True
+
       it "returns True" $ do
-        withEnvironment [] $ do
-          H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` True
+        H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` True
 
       context "when NO_COLOR is set" $ do
         it "returns False" $ do

--- a/test/regression/issue-270/run.sh
+++ b/test/regression/issue-270/run.sh
@@ -3,7 +3,7 @@ set -o errexit
 cd `dirname "$0"`
 ghc -fforce-recomp Spec.hs
 
-./Spec -f silent > result & pid=$!
+./Spec -f silent --no-color > result & pid=$!
 sleep 1
 kill -SIGINT $pid
 wait $pid || output=$(cat result)


### PR DESCRIPTION
Use `HSPEC_COLOR=no` or `--no-color` to opt out of this.