### PR TITLE
Add a nix shell environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1648297722,
+        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1648097358,
+        "narHash": "sha256-GMoTKP/po2Nbkh1tvPvP8Ww6NyFW8FFst1Z3nfzffZc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4d60081494259c0785f7e228518fee74e0792c1b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4d60081494259c0785f7e228518fee74e0792c1b",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "hspec";
+  inputs = {
+    # To find a suitable nixpkgs hash with cache, pick one from https://status.nixos.org/
+    nixpkgs.url = "github:nixos/nixpkgs/4d60081494259c0785f7e228518fee74e0792c1b";
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-utils.inputs.nixpkgs.follows = "nixpkgs";
+  };
+  outputs = inputs@{ self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          # Because: https://zimbatm.com/notes/1000-instances-of-nixpkgs
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          devShell = pkgs.mkShell {
+            buildInputs = [
+              pkgs.ghc
+              pkgs.cabal-install
+              pkgs.haskellPackages.haskell-language-server
+            ];
+          };
+        }
+      );
+}


### PR DESCRIPTION
This PR doesn't fully nixify the project (I assume no active maintainer uses Nix), but it does add a minimal nix-shell setup for potential contributors, like me, who use Nix on a daily basis and do not have Haskell tools installed globally.

See https://nixos.wiki/wiki/Development_environment_with_nix-shell

The `flake.nix` should require little to no maintenance over time.
