### PR TITLE
Disable progress reporting when `GITHUB_ACTIONS=true`

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Format.hs
+++ b/hspec-core/src/Test/Hspec/Core/Format.hs
@@ -56,6 +56,7 @@ data Event =
 
 data FormatConfig = FormatConfig {
   formatConfigUseColor :: Bool
+, formatConfigReportProgress :: Bool
 , formatConfigOutputUnicode :: Bool
 , formatConfigUseDiff :: Bool
 , formatConfigPrettyPrint :: Bool

--- a/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
@@ -208,8 +208,8 @@ overwriteWith old new
 
 writeTransient :: String -> FormatM ()
 writeTransient new = do
-  useColor <- getConfig formatConfigUseColor
-  when (useColor) $ do
+  reportProgress <- getConfig formatConfigReportProgress
+  when (reportProgress) $ do
     old <- gets stateTransientOutput
     write $ old `overwriteWith` new
     modify $ \ state -> state {stateTransientOutput = new}

--- a/hspec-core/test/Test/Hspec/Core/Formatters/V2Spec.hs
+++ b/hspec-core/test/Test/Hspec/Core/Formatters/V2Spec.hs
@@ -24,6 +24,7 @@ testSpec = do
 formatConfig :: FormatConfig
 formatConfig = FormatConfig {
   formatConfigUseColor = False
+, formatConfigReportProgress = False
 , formatConfigOutputUnicode = True
 , formatConfigUseDiff = True
 , formatConfigPrettyPrint = True

--- a/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
@@ -582,26 +582,26 @@ spec = do
       let isTerminalDevice = return False
 
       it "returns False" $ do
-        H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` False
+        H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` (False, False)
 
       context "with GITHUB_ACTIONS=true" $ do
         it "returns True" $ do
           withEnvironment [("GITHUB_ACTIONS", "true")] $ do
-            H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` True
+            H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` (False, True)
 
     context "with a terminal device" $ do
 
       let isTerminalDevice = return True
 
       it "returns True" $ do
-        H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` True
+        H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` (True, True)
 
       context "when NO_COLOR is set" $ do
         it "returns False" $ do
           withEnvironment [("NO_COLOR", "yes")] $ do
-            H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` False
+            H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` (False, False)
 
-  describe "colorOutputSupported" $ do
+  describe "unicodeOutputSupported" $ do
     context "with UnicodeAlways" $ do
       it "returns True" $ do
         H.unicodeOutputSupported H.UnicodeAlways undefined `shouldReturn` True


### PR DESCRIPTION
GitHub Actions does not interpret `\r`.  For that reason any transient out is never erased, resulting in duplicated output.

Disabling progress reporting prevents that duplicated output.

Before:
![screen](https://user-images.githubusercontent.com/461132/161254229-8158d482-5129-49ba-b66f-570595a01ce3.png)
After:
![screen2](https://user-images.githubusercontent.com/461132/161263564-9790ea5f-dee7-4708-a78c-b3fa5414a52e.png)

