### PR TITLE
Handle pretty-printing in `Test.Hspec.Core.Runner.Eval`

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Formatters/V2.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/V2.hs
@@ -131,7 +131,6 @@ import Test.Hspec.Core.Formatters.Internal (
   )
 
 import           Test.Hspec.Core.Formatters.Diff
-import           Test.Hspec.Core.Formatters.Pretty (pretty2)
 
 silent :: Formatter
 silent = Formatter {
@@ -274,13 +273,7 @@ defaultFailedFormatter = do
       case reason of
         NoReason -> return ()
         Reason err -> withFailColor $ indent err
-        ExpectedButGot preface expected_ actual_ -> do
-          pretty <- prettyPrint
-          let
-            (expected, actual)
-              | pretty = pretty2 unicode expected_ actual_
-              | otherwise = (expected_, actual_)
-
+        ExpectedButGot preface expected actual -> do
           mapM_ indent preface
 
           b <- useDiff

--- a/hspec-core/src/Test/Hspec/Core/Runner.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner.hs
@@ -103,6 +103,7 @@ import           Test.Hspec.Core.Config
 import           Test.Hspec.Core.Format (FormatConfig(..))
 import qualified Test.Hspec.Core.Formatters.V1 as V1
 import qualified Test.Hspec.Core.Formatters.V2 as V2
+import           Test.Hspec.Core.Formatters.Pretty (pretty2)
 import           Test.Hspec.Core.FailureReport
 import           Test.Hspec.Core.QuickCheckUtil
 import           Test.Hspec.Core.Shuffle
@@ -316,6 +317,7 @@ runEvalTree config spec = do
     let
       evalConfig = EvalConfig {
         evalConfigFormat = format
+      , evalConfigPrettyPrint = if configPrettyPrint config then pretty2 outputUnicode else (,)
       , evalConfigConcurrentJobs = concurrentJobs
       , evalConfigFailFast = configFailFast config
       }

--- a/hspec-core/src/Test/Hspec/Core/Runner/Eval.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner/Eval.hs
@@ -69,6 +69,7 @@ type MonadIO m = (Monad m, M.MonadIO m)
 
 data EvalConfig = EvalConfig {
   evalConfigFormat :: Format
+, evalConfigPrettyPrint :: String -> String -> (String, String)
 , evalConfigConcurrentJobs :: Int
 , evalConfigFailFast :: Bool
 }
@@ -108,11 +109,13 @@ reportItemDone path item = do
 
 reportResult :: Path -> Maybe Location -> (Seconds, Result) -> EvalM ()
 reportResult path loc (duration, result) = do
+  prettyPrint <- asks (evalConfigPrettyPrint . envConfig)
   case result of
     Result info status -> reportItemDone path $ Format.Item loc duration info $ case status of
       Success                      -> Format.Success
       Pending loc_ reason          -> Format.Pending loc_ reason
       Failure loc_ err@(Error _ e) -> Format.Failure (loc_ <|> extractLocation e) err
+      Failure loc_ (ExpectedButGot pre expected actual) -> Format.Failure loc_ $ uncurry (ExpectedButGot pre) (prettyPrint expected actual)
       Failure loc_ err             -> Format.Failure loc_ err
 
 groupStarted :: Path -> EvalM ()

--- a/hspec-core/test/Test/Hspec/Core/Formatters/V2Spec.hs
+++ b/hspec-core/test/Test/Hspec/Core/Formatters/V2Spec.hs
@@ -204,25 +204,6 @@ spec = do
           ]
 
     describe "formatterDone" $ do
-      it "recovers unicode from ExpectedButGot" $ do
-        formatter <- formatterToFormat failed_examples formatConfig { formatConfigOutputUnicode = True }
-        _ <- formatter .  ItemDone ([], "") . Item Nothing 0 "" $ Failure Nothing $ ExpectedButGot Nothing (show "\955") (show "\956")
-        (fmap normalizeSummary . captureLines) (formatter $ Done []) `shouldReturn` [
-            ""
-          , "Failures:"
-          , ""
-          , "  1) "
-          , "       expected: \"λ\""
-          , "        but got: \"μ\""
-          , ""
-          , "  To rerun use: --match \"//\""
-          , ""
-          , "Randomized with seed 0"
-          , ""
-          , "Finished in 0.0000 seconds"
-          , "1 example, 1 failure"
-          ]
-
       context "when actual/expected contain newlines" $ do
         it "adds indentation" $ do
           formatter <- formatterToFormat failed_examples formatConfig

--- a/hspec-core/test/Test/Hspec/Core/HooksSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/HooksSpec.hs
@@ -25,6 +25,7 @@ evalSpec = fmap normalize . (toEvalForest >=> runFormatter config)
   where
     config = EvalConfig {
       evalConfigFormat = \ _ -> return ()
+    , evalConfigPrettyPrint = (,)
     , evalConfigConcurrentJobs = 1
     , evalConfigFailFast = False
     }


### PR DESCRIPTION
(instead of `Test.Hspec.Core.Formatters.V2`)