### PR TITLE
Ensure that interim output does not interfere with output from tests

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
@@ -42,7 +42,6 @@ module Test.Hspec.Core.Formatters.Internal (
 
 #ifdef TEST
 , runFormatM
-, overwriteWith
 , splitLines
 #endif
 ) where
@@ -52,7 +51,7 @@ import           Test.Hspec.Core.Compat
 
 import qualified System.IO as IO
 import           System.IO (Handle, stdout)
-import           Control.Exception (bracket_)
+import           Control.Exception (bracket_, bracket)
 import           System.Console.ANSI
 import           Control.Monad.Trans.State hiding (state, gets, modify)
 import           Control.Monad.IO.Class
@@ -95,7 +94,6 @@ formatterToFormat Formatter{..} config = monadic (runFormatM config) $ \ event -
   Progress path progress -> formatterProgress path progress
   ItemStarted path -> formatterItemStarted path
   ItemDone path item -> do
-    clearTransientOutput
     case itemResult item of
       Success {} -> increaseSuccessCount
       Pending {} -> increasePendingCount
@@ -156,7 +154,6 @@ data FormatterState = FormatterState {
 , stateFailMessages    :: [FailureRecord]
 , stateCpuStartTime    :: Maybe Integer
 , stateStartTime       :: Seconds
-, stateTransientOutput :: String
 , stateConfig          :: FormatConfig
 , stateColor           :: Maybe SGR
 }
@@ -177,11 +174,15 @@ newtype FormatM a = FormatM (StateT (IORef FormatterState) IO a)
   deriving (Functor, Applicative, Monad, MonadIO)
 
 runFormatM :: FormatConfig -> FormatM a -> IO a
-runFormatM config (FormatM action) = do
+runFormatM config (FormatM action) = withLineBuffering $ do
   time <- getMonotonicTime
   cpuTime <- if (formatConfigPrintCpuTime config) then Just <$> CPUTime.getCPUTime else pure Nothing
-  st <- newIORef (FormatterState 0 0 [] cpuTime time "" config Nothing)
+  st <- newIORef (FormatterState 0 0 [] cpuTime time config Nothing)
   evalStateT action st
+
+withLineBuffering :: IO a -> IO a
+withLineBuffering action = bracket (IO.hGetBuffering stdout) (IO.hSetBuffering stdout) $ \ _ -> do
+  IO.hSetBuffering stdout IO.LineBuffering >> action
 
 -- | Increase the counter for successful examples
 increaseSuccessCount :: FormatM ()
@@ -212,29 +213,14 @@ getFailMessages = reverse `fmap` gets stateFailMessages
 getExpectedTotalCount :: FormatM Int
 getExpectedTotalCount = getConfig formatConfigExpectedTotalCount
 
-overwriteWith :: String -> String -> String
-overwriteWith old new
-  | n == 0 = new
-  | otherwise = '\r' : new ++ replicate (n - length new) ' '
-  where
-    n = length old
-
 writeTransient :: String -> FormatM ()
 writeTransient new = do
   reportProgress <- getConfig formatConfigReportProgress
   when (reportProgress) $ do
-    old <- gets stateTransientOutput
-    write $ old `overwriteWith` new
-    modify $ \ state -> state {stateTransientOutput = new}
     h <- getHandle
+    write $ new
     liftIO $ IO.hFlush h
-
-clearTransientOutput :: FormatM ()
-clearTransientOutput = do
-  n <- length <$> gets stateTransientOutput
-  unless (n == 0) $ do
-    write ("\r" ++ replicate n ' ' ++ "\r")
-    modify $ \ state -> state {stateTransientOutput = ""}
+    write $ "\r" ++ replicate (length new) ' ' ++ "\r"
 
 -- | Append some output to the report.
 write :: String -> FormatM ()

--- a/hspec-core/test/Test/Hspec/Core/Formatters/InternalSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/Formatters/InternalSpec.hs
@@ -34,23 +34,6 @@ spec = do
         withSuccessColor $ write "foo\nbar\nbaz\n"
       `shouldReturn` unlines [green "foo", green "bar", green "baz"]
 
-  describe "overwriteWith" $ do
-    context "when old is null" $ do
-      it "returns new" $ do
-        ("" `overwriteWith` "foo") `shouldBe` "foo"
-
-    context "when old and new have the same length" $ do
-      it "overwrites old" $ do
-        ("foo" `overwriteWith` "bar") `shouldBe` "\rbar"
-
-    context "when old is shorter than new" $ do
-      it "overwrites old" $ do
-        ("ba" `overwriteWith` "foo") `shouldBe` "\rfoo"
-
-    context "when old is longer than new" $ do
-      it "overwrites old" $ do
-        ("foobar" `overwriteWith` "foo") `shouldBe` "\rfoo   "
-
   describe "splitLines" $ do
     it "splits a string into chunks" $ do
       splitLines "foo\nbar\nbaz" `shouldBe` ["foo", "\n", "bar", "\n", "baz"]


### PR DESCRIPTION
This facilitates using `print` when debugging test cases.

Given:
```haskell
spec :: Spec
spec = do
  describe "reverse" $ do
    it "reverses a list" $ do
      threadDelay 500000
      putStrLn "Hi there 👋"
      threadDelay 500000
      reverse [1 :: Int, 2, 3] `shouldBe` [3, 2, 1]

```

Before:
![before](https://user-images.githubusercontent.com/461132/163572178-1941ed1a-aca8-42c4-93d2-9544efe6c4f4.png)

After:
![after](https://user-images.githubusercontent.com/461132/163572172-acc41832-ae20-4f5a-a977-03b95ce21149.png)
