### PR TITLE
fix typos

### DIFF
--- a/doc/js/jquery.scrollintoview.js
+++ b/doc/js/jquery.scrollintoview.js
@@ -194,7 +194,7 @@
 					scroll: element.scrollWidth,
 					client: element.clientWidth
 				},
-				// check overflow.x/y because iPad (and possibly other tablets) don't display scrollbars
+				// check overflow.x/y because iPad (and possibly other tablets) don't dislay scrollbars
 				scrollableX: function () {
 					return (overflow.x || overflow.isRoot) && this.width.scroll > this.width.client;
 				},

--- a/doc/js/jquery.scrollintoview.js
+++ b/doc/js/jquery.scrollintoview.js
@@ -194,7 +194,7 @@
 					scroll: element.scrollWidth,
 					client: element.clientWidth
 				},
-				// check overflow.x/y because iPad (and possibly other tablets) don't dislay scrollbars
+				// check overflow.x/y because iPad (and possibly other tablets) don't display scrollbars
 				scrollableX: function () {
 					return (overflow.x || overflow.isRoot) && this.width.scroll > this.width.client;
 				},

--- a/hspec-core/test/Test/Hspec/Core/UtilSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/UtilSpec.hs
@@ -95,7 +95,7 @@ spec = do
     it "creates a sentence from a subject and a requirement" $ do
       formatRequirement (["reverse"], "reverses a list") `shouldBe` "reverse reverses a list"
 
-    it "creates a sentence from a subject and a requirement when the subject consits of multiple words" $ do
+    it "creates a sentence from a subject and a requirement when the subject consists of multiple words" $ do
       formatRequirement (["The reverse function"], "reverses a list") `shouldBe` "The reverse function reverses a list"
 
     it "returns the requirement if no subject is given" $ do


### PR DESCRIPTION
doc/js/jquery.scrollintoview.js
hspec-core/test/Test/Hspec/Core/UtilSpec.hs

CHANGES.markdown (contains typos, unmodified)

```sh
$ grep -n desribes CHANGES.markdown
638:Specs consisting of several *desribes*, combined with `descriptions`, continue
$ grep -n upcomming CHANGES.markdown
325:    this with the upcomming cleanup actions #188)
$ 
```