### PR TITLE
Call release only when acquired in hooks

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Hooks.hs
+++ b/hspec-core/src/Test/Hspec/Core/Hooks.hs
@@ -2,6 +2,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ConstraintKinds #-}
+#if __GLASGOW_HASKELL__ < 710
+{-# LANGUAGE DeriveDataTypeable #-}
+#endif
 -- | Stability: provisional
 module Test.Hspec.Core.Hooks (
   before

--- a/hspec-core/src/Test/Hspec/Core/Hooks.hs
+++ b/hspec-core/src/Test/Hspec/Core/Hooks.hs
@@ -33,6 +33,7 @@ module Test.Hspec.Core.Hooks (
 import           Prelude ()
 import           Test.Hspec.Core.Compat
 import           Data.CallStack (HasCallStack)
+import           Data.Typeable (Typeable)
 
 import           Control.Exception (Exception, SomeException, finally, throwIO, try)
 import           Control.Concurrent
@@ -142,7 +143,7 @@ data OrderedAcquireReleaseState
 data OrderedAcquireReleaseException
   = HasAlreadyBeenAcquired
   | HasAlreadyBeenReleased
-  deriving Show
+  deriving (Show, Typeable)
 
 instance Exception OrderedAcquireReleaseException
 

--- a/hspec-core/test/Test/Hspec/Core/HooksSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/HooksSpec.hs
@@ -504,6 +504,36 @@ spec = do
         , "after"
         ]
 
+    it "wrap actions around a spec in order" $ do
+      (rec, retrieve) <- mkAppend
+      let action i inner = rec ("before " <> i) *> inner <* rec ("after " <> i)
+      evalSpec_ $ H.aroundAll_ (action "1") $ H.aroundAll_ (action "2") $ do
+        H.it "foo" $ rec "foo"
+        H.it "bar" $ rec "bar"
+      retrieve `shouldReturn` [
+          "before 1"
+        , "before 2"
+        , "foo"
+        , "bar"
+        , "after 2"
+        , "after 1"
+        ]
+
+    it "does not call actions wrapped around a failing action" $ do
+      (rec, retrieve) <- mkAppend
+      let action i inner = rec ("before " <> i) *> inner <* rec ("after " <> i)
+      evalSpec_ $
+        H.aroundAll_ (action "1") $ 
+          H.aroundAll_ (action "2 failing" . const throwException) $ 
+            H.aroundAll_ (action "3") $ do
+              H.it "foo" $ rec "foo"
+              H.it "bar" $ rec "bar"
+      retrieve `shouldReturn` [
+          "before 1"
+        , "before 2 failing"
+        , "after 1"
+        ]
+
     it "does not memoize subject" $ do
       mock <- newMock
       let action :: IO Int
@@ -557,6 +587,36 @@ spec = do
         ]
       mockCounter mock `shouldReturn` 3
 
+    it "wrap actions around a spec in order" $ do
+      (rec, retrieve) <- mkAppend
+      let action i inner a = rec ("before " <> i) *> inner a <* rec ("after " <> i)
+      evalSpec_ $ H.aroundAllWith (action "1") $ H.aroundAllWith (action "2") $ do
+        H.it "foo" $ rec "foo"
+        H.it "bar" $ rec "bar"
+      retrieve `shouldReturn` [
+          "before 1"
+        , "before 2"
+        , "foo"
+        , "bar"
+        , "after 2"
+        , "after 1"
+        ]
+
+    it "does not call actions wrapped around a failing action" $ do
+      (rec, retrieve) <- mkAppend
+      let action i inner a = rec ("before " <> i) *> inner a <* rec ("after " <> i)
+      evalSpec_ $
+        H.aroundAllWith (action "1") $ 
+          H.aroundAllWith (action "2 failing" . const . const throwException) $ 
+            H.aroundAllWith (action "3") $ do
+              H.it "foo" $ rec "foo"
+              H.it "bar" $ rec "bar"
+      retrieve `shouldReturn` [
+          "before 1"
+        , "before 2 failing"
+        , "after 1"
+        ]
+
     it "reports exceptions on acquire" $ do
       evalSpec $ do
         H.aroundAllWith (\ action () -> throwException >>= action) $ do
@@ -575,6 +635,42 @@ spec = do
       , item ["bar"] $ divideByZeroIn "aroundAllWith"
       ]
 
+  describe "orderedAcquireAndRelease" $ do
+    it "calls acquire and release in order" $ do
+      (rec, retrieve) <- mkAppend
+      let acquire i = rec ("acquire " <> i)
+          release = rec "release"
+      (doAcquire, doRelease) <- H.orderedAcquireAndRelease (acquire, release)
+      doAcquire "arg"
+      doRelease
+      retrieve `shouldReturn` [
+          "acquire arg"
+        , "release"
+        ]
+
+    it "ignore calls to release if acquire has not been called" $ do
+      (rec, retrieve) <- mkAppend
+      let acquire _ = pure ()
+          release = rec "release"
+      (_, doRelease) <- H.orderedAcquireAndRelease (acquire, release)
+      doRelease
+      retrieve `shouldReturn` []
+
+    context "with an exception during the resource acquisition" $ do
+      it "propagates that exception" $ do
+        let acquire _ = throwException
+            release = pure ()
+        (doAcquire, _) <- H.orderedAcquireAndRelease (acquire, release)
+        doAcquire "whatever" `shouldThrow` (== DivideByZero)
+
+    context "with an exception during resource deallocation" $ do
+      it "propagates that exception" $ do
+        let acquire _ = pure ()
+            release = throwException
+        (doAcquire, doRelease) <- H.orderedAcquireAndRelease (acquire, release)
+        doAcquire "whatever"
+        doRelease `shouldThrow` (== DivideByZero)
+
   describe "decompose" $ do
     it "decomposes a with-style action into acquire / release" $ do
       (acquire, release) <- H.decompose $ \ action x -> do
@@ -584,9 +680,8 @@ spec = do
 
     context "with an exception during resource acquisition" $ do
       it "propagates that exception" $ do
-        (acquire, release) <- H.decompose $ \ action () -> do
+        (acquire, release) <- H.decompose $ \ _ () -> do
           throwException_
-          action ()
         acquire () `shouldThrow` (== DivideByZero)
         release
 

--- a/hspec-core/test/Test/Hspec/Core/HooksSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/HooksSpec.hs
@@ -523,8 +523,8 @@ spec = do
       (rec, retrieve) <- mkAppend
       let action i inner = rec ("before " <> i) *> inner <* rec ("after " <> i)
       evalSpec_ $
-        H.aroundAll_ (action "1") $ 
-          H.aroundAll_ (action "2 failing" . const throwException) $ 
+        H.aroundAll_ (action "1") $
+          H.aroundAll_ (action "2 failing" . const throwException) $
             H.aroundAll_ (action "3") $ do
               H.it "foo" $ rec "foo"
               H.it "bar" $ rec "bar"
@@ -606,8 +606,8 @@ spec = do
       (rec, retrieve) <- mkAppend
       let action i inner a = rec ("before " <> i) *> inner a <* rec ("after " <> i)
       evalSpec_ $
-        H.aroundAllWith (action "1") $ 
-          H.aroundAllWith (action "2 failing" . const . const throwException) $ 
+        H.aroundAllWith (action "1") $
+          H.aroundAllWith (action "2 failing" . const . const throwException) $
             H.aroundAllWith (action "3") $ do
               H.it "foo" $ rec "foo"
               H.it "bar" $ rec "bar"


### PR DESCRIPTION
This PR fixes an issue when the `release` action in `aroundAll_` and `aroundAllWith` is called when the `acquire` action was not, causing a deadlock.

This situation can happen with multiple `aroundAll_` / `aroundAllWith` when one of the earlier `acquire` action has failed but the `release` actions of uncalled `acquire` still get executed.

Fixes #679.