### PR TITLE
Compute diffs (actual, expected) concurrently

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Format.hs
+++ b/hspec-core/src/Test/Hspec/Core/Format.hs
@@ -5,6 +5,7 @@
 module Test.Hspec.Core.Format (
   Format
 , FormatConfig(..)
+, PrettyPrintFunction
 , Event(..)
 , Progress
 , Path
@@ -60,13 +61,15 @@ data FormatConfig = FormatConfig {
 , formatConfigOutputUnicode :: Bool
 , formatConfigUseDiff :: Bool
 , formatConfigPrettyPrint :: Bool -- ^ Deprecated: use `formatConfigPrettyPrintFunction` instead
-, formatConfigPrettyPrintFunction :: Maybe (String -> String -> (String, String))
+, formatConfigPrettyPrintFunction :: Maybe PrettyPrintFunction
 , formatConfigPrintTimes :: Bool
 , formatConfigHtmlOutput :: Bool
 , formatConfigPrintCpuTime :: Bool
 , formatConfigUsedSeed :: Integer
 , formatConfigExpectedTotalCount :: Int
 }
+
+type PrettyPrintFunction = String -> String -> (String, String)
 
 data Signal = Ok | NotOk SomeException
 

--- a/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
@@ -120,7 +120,7 @@ prettyPrint = maybe False (const True) <$> getConfig formatConfigPrettyPrintFunc
 -- `Nothing` otherwise.
 --
 -- @since 2.10.0
-prettyPrintFunction :: FormatM (Maybe (String -> String -> (String, String)))
+prettyPrintFunction :: FormatM (Maybe PrettyPrintFunction)
 prettyPrintFunction = getConfig formatConfigPrettyPrintFunction
 
 -- | Return `True` if the user requested unicode output, `False` otherwise.


### PR DESCRIPTION
In our code base, during a heavy refactoring, we had the issue having a lot (~250) of test failing quickly (mostly HTTP endpoints) hence the total execution was taking a lot of time (50s to run the tests, in parallel, 10 minutes to have all the results, one by one).

After a bit of code review, it appears that, while tests can be run in parallel, results are computed (especially the diff algorithm) sequentially.

To emphasis my issue I came up with a simple case:

```haskell
module Main where

import Control.Monad
import Data.List
import Test.Hspec

main :: IO ()
main = do
  hspec $
    parallel $ do
      forM_ ([0 .. 10] :: [Int]) $ \_ ->
        it "Quick test" $ do
          shouldBe (show left) (show right)

data S = S
  { t :: String,
    f0 :: Maybe S,
    f1 :: Maybe S,
    f2 :: Maybe S,
    f3 :: Maybe S
  }
  deriving (Eq, Show)

data T = T
  { u :: String,
    g5 :: Maybe T,
    g6 :: Maybe T,
    g7 :: Maybe T,
    h8 :: Maybe T
  }
  deriving (Eq, Show)

left :: Maybe S
left = mkS "azrtqyui"

right :: Maybe T
right = mkT "azmXauryt"

mkS :: String -> Maybe S
mkS x =
  case permutations x of
    (t' : f0' : f1' : f2' : f3' : _) -> Just $ S t' (mkS (tail f0')) (mkS (tail f1')) (mkS (tail f2')) (mkS (tail f3'))
    _ -> Nothing

mkT :: String -> Maybe T
mkT x =
  case permutations x of
    (t' : f0' : f1' : f2' : f3' : _) -> Just $ T t' (mkT (tail f3')) (mkT (tail f2')) (mkT (tail f0')) (mkT (tail f1'))
    _ -> Nothing
```

which, once execute, gives:

```
	Sun Aug  7 10:57 2022 Time and Allocation Profiling Report  (Final)

	   slow +RTS -N20 -p -RTS --times

	total time  =        4.94 secs   (13936 ticks @ 1000 us, 20 processors)
	total alloc = 46,118,315,688 bytes  (excludes profiling overheads)
```

and

```
cabal exec slow -- +RTS -N20 -p -RTS --times  29.8s user 1.94s system 139% cpu 26.3 total
```

My PR, which is still a draft:

```
	Sun Aug  7 15:44 2022 Time and Allocation Profiling Report  (Final)

	   slow +RTS -N20 -p -RTS --times

	total time  =        7.65 secs   (21577 ticks @ 1000 us, 20 processors)
	total alloc = 12,257,225,264 bytes  (excludes profiling overheads)
```

and

```
cabal exec slow -- +RTS -N20 -p -RTS --times  27.78s user 1.94s system 377% cpu 7.873 total
```

I'd like to gather feedback regarding:
* Is it relevant to be integrated into hspec?
* what would be a better design? (for the moment it's a proof of concept, from the top of my head, I can add a configuration for the parallelism, or compute the diff at the end of each test)
* Anything relative to performance (I barely get a x4 on a 20 threads CPU)