### PR TITLE
HLint suggestions for `hspec-discover`

### DIFF
--- a/hspec-discover/src/Test/Hspec/Discover/Config.hs
+++ b/hspec-discover/src/Test/Hspec/Discover/Config.hs
@@ -35,9 +35,9 @@ usage prog = "\nUsage: " ++ prog ++ " SRC CUR DST [--module-name=NAME]\n"
 parseConfig :: String -> [String] -> Either String Config
 parseConfig prog args = case getOpt Permute options args of
     (opts, [], []) -> let
-        c = (foldl (flip id) defaultConfig opts)
+        c = foldl (flip id) defaultConfig opts
       in
-        if (configNoMain c && isJust (configFormatter c))
+        if configNoMain c && isJust (configFormatter c)
            then
              formatError "option `--formatter=<fmt>' does not make sense with `--no-main'\n"
            else

--- a/hspec-discover/src/Test/Hspec/Discover/Run.hs
+++ b/hspec-discover/src/Test/Hspec/Discover/Run.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, OverloadedStrings #-}
+{-# LANGUAGE FlexibleInstances, OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 -- | A preprocessor that finds and combines specs.
 --
@@ -117,9 +117,7 @@ sequenceS :: [ShowS] -> ShowS
 sequenceS = foldr (.) "" . intersperse " >> "
 
 formatSpecs :: Maybe [Spec] -> ShowS
-formatSpecs specs = case specs of
-  Nothing -> "return ()"
-  Just xs -> fromForest xs
+formatSpecs = maybe "return ()" fromForest
   where
     fromForest :: [Spec] -> ShowS
     fromForest = sequenceS . map fromTree

--- a/hspec-discover/src/Test/Hspec/Discover/Sort.hs
+++ b/hspec-discover/src/Test/Hspec/Discover/Sort.hs
@@ -15,7 +15,7 @@ import           Data.Ord
 sortNaturallyBy :: (a -> (String, Int)) -> [a] -> [a]
 sortNaturallyBy f = sortBy (comparing ((\ (k, t) -> (naturalSortKey k, t)) . f))
 
-data NaturalSortKey = NaturalSortKey [Chunk]
+newtype NaturalSortKey = NaturalSortKey [Chunk]
   deriving (Eq, Ord)
 
 data Chunk = Numeric Integer Int | Textual [(Char, Char)]


### PR DESCRIPTION
The Hspec CI tests from GHC 7.4.1/base-4.5.0.0 (released 2 February 2012), so the following HLint suggestions have been ignored:

~~~
hspec-discover\src\Test\Hspec\Discover\Sort.hs:16:21-80: Warning: Use sortOn
Found:
  sortBy (comparing ((\ (k, t) -> (naturalSortKey k, t)) . f))
Perhaps:
  sortOn ((\ (k, t) -> (naturalSortKey k, t)) . f)

hspec-discover\src\Test\Hspec\Discover\Sort.hs:16:41-73: Suggestion: Use first
Found:
  \ (k, t) -> (naturalSortKey k, t)
Perhaps:
  Data.Bifunctor.first naturalSortKey
Note: increases laziness
~~~

`Data.List.sortOn` and `Data.Bifunctor.first` first provided by `base-4.8.0.0` (GHC 7.10.1, released April 2015).