### PR TITLE
Suppress excessive diff output

### DIFF
--- a/changes/716.md
+++ b/changes/716.md
@@ -1,0 +1,1 @@
+  - Suppress excessive diff output (#449)

--- a/hspec-core/help.txt
+++ b/hspec-core/help.txt
@@ -35,6 +35,8 @@ FORMATTER OPTIONS
            --[no-]color            colorize the output
            --[no-]unicode          output unicode
            --[no-]diff             show colorized diffs
+           --diff-context=N        output N lines of diff context (default: 3)
+                                   use a value of 'full' to see the full context
            --[no-]pretty           try to pretty-print diff values
            --[no-]times            report times for individual spec items
            --print-cpu-time        include used CPU time in summary

--- a/hspec-core/src/Test/Hspec/Core/Compat.hs
+++ b/hspec-core/src/Test/Hspec/Core/Compat.hs
@@ -27,6 +27,7 @@ import           Data.List as Imports (
     stripPrefix
   , isPrefixOf
   , isInfixOf
+  , isSuffixOf
   , intercalate
   , inits
   , tails
@@ -171,3 +172,6 @@ infixl 1 <&>
 (<&>) :: Functor f => f a -> (a -> b) -> f b
 (<&>) = flip (<$>)
 #endif
+
+endsWith :: Eq a => [a] -> [a] -> Bool
+endsWith = flip isSuffixOf

--- a/hspec-core/src/Test/Hspec/Core/Format.hs
+++ b/hspec-core/src/Test/Hspec/Core/Format.hs
@@ -59,6 +59,7 @@ data FormatConfig = FormatConfig {
 , formatConfigReportProgress :: Bool
 , formatConfigOutputUnicode :: Bool
 , formatConfigUseDiff :: Bool
+, formatConfigDiffContext :: Maybe Int
 , formatConfigPrettyPrint :: Bool -- ^ Deprecated: use `formatConfigPrettyPrintFunction` instead
 , formatConfigPrettyPrintFunction :: Maybe (String -> String -> (String, String))
 , formatConfigPrintTimes :: Bool

--- a/hspec-core/src/Test/Hspec/Core/Formatters/Diff.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/Diff.hs
@@ -15,11 +15,73 @@ import           Test.Hspec.Core.Compat hiding (First)
 import           Data.Char
 import qualified Data.Algorithm.Diff as Diff
 
-data Diff = First String | Second String | Both String
+data Diff = First String | Second String | Both String | Omitted Int
   deriving (Eq, Show)
 
-diff :: String -> String -> [Diff]
-diff expected actual = map (toDiff . fmap concat) $ Diff.getGroupedDiff (partition expected) (partition actual)
+-- |
+-- Split a string at line boundaries.
+--
+-- >>> splitLines "foo\nbar\nbaz"
+-- ["foo\n","bar\n","baz"]
+--
+-- prop> concat (splitLines xs) == xs
+splitLines :: String -> [String]
+splitLines = go
+  where
+    go xs = case break (== '\n') xs of
+      (ys, '\n' : zs) -> (ys ++ ['\n']) : go zs
+      ("", "") -> []
+      _ -> [xs]
+
+data TrimMode = FirstChunck | Chunck | LastChunck
+
+trim :: Int -> [Diff] -> [Diff]
+trim context = \ chunks -> case chunks of
+  [] -> []
+  x : xs -> trimChunk FirstChunck x (go xs)
+  where
+    omitThreshold = 3
+
+    go chunks = case chunks of
+      [] -> []
+      [x] -> trimChunk LastChunck x []
+      x : xs -> trimChunk Chunck x (go xs)
+
+    trimChunk mode chunk = case chunk of
+      Both xs | omitted >= omitThreshold -> keep start . (Omitted omitted :) . keep end
+        where
+          omitted :: Int
+          omitted = n - keepStart - keepEnd
+
+          keepStart :: Int
+          keepStart = case mode of
+            FirstChunck -> 0
+            _ -> succ context
+
+          keepEnd :: Int
+          keepEnd = case mode of
+            LastChunck -> 0
+            _ -> if xs `endsWith` "\n" then context else succ context
+
+          n :: Int
+          n = length allLines
+
+          allLines :: [String]
+          allLines = splitLines xs
+
+          start :: [String]
+          start = take keepStart allLines
+
+          end :: [String]
+          end = drop (keepStart + omitted) allLines
+      _ -> (chunk :)
+
+    keep xs
+      | null xs = id
+      | otherwise = (Both (concat xs) :)
+
+diff :: Maybe Int -> String -> String -> [Diff]
+diff context expected actual = maybe id trim context $ map (toDiff . fmap concat) $ Diff.getGroupedDiff (partition expected) (partition actual)
 
 toDiff :: Diff.Diff String -> Diff
 toDiff d = case d of

--- a/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
@@ -35,6 +35,7 @@ module Test.Hspec.Core.Formatters.Internal (
 , outputUnicode
 
 , useDiff
+, diffContext
 , prettyPrint
 , prettyPrintFunction
 , extraChunk
@@ -110,6 +111,13 @@ getFailCount = length <$> getFailMessages
 -- | Return `True` if the user requested colorized diffs, `False` otherwise.
 useDiff :: FormatM Bool
 useDiff = getConfig formatConfigUseDiff
+
+-- |
+-- Return the value of `Test.Hspec.Core.Runner.configDiffContext`.
+--
+-- @since 2.10.6
+diffContext :: FormatM (Maybe Int)
+diffContext = getConfig formatConfigDiffContext
 
 -- | Return `True` if the user requested pretty diffs, `False` otherwise.
 prettyPrint :: FormatM Bool

--- a/hspec-core/src/Test/Hspec/Core/Formatters/V1.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/V1.hs
@@ -288,7 +288,7 @@ defaultFailedFormatter = do
           let threshold = 2 :: Seconds
 
           mchunks <- liftIO $ if b
-            then timeout threshold (evaluate $ diff expected actual)
+            then timeout threshold (evaluate $ diff Nothing expected actual)
             else return Nothing
 
           case mchunks of
@@ -307,6 +307,7 @@ defaultFailedFormatter = do
                 Both a -> indented write a
                 First a -> indented extra a
                 Second _ -> return ()
+                Omitted _ -> return ()
               writeLine ""
 
               withFailColor $ write (indentation ++ " but got: ")
@@ -314,6 +315,7 @@ defaultFailedFormatter = do
                 Both a -> indented write a
                 First _ -> return ()
                 Second a -> indented missing a
+                Omitted _ -> return ()
               writeLine ""
 
         Error _ e -> withFailColor . indent $ (("uncaught exception: " ++) . formatException) e

--- a/hspec-core/src/Test/Hspec/Core/Runner.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner.hs
@@ -338,6 +338,7 @@ runEvalTree config spec = do
       , formatConfigReportProgress = reportProgress
       , formatConfigOutputUnicode = outputUnicode
       , formatConfigUseDiff = configDiff config
+      , formatConfigDiffContext = configDiffContext config
       , formatConfigPrettyPrint = configPrettyPrint config
       , formatConfigPrettyPrintFunction = if configPrettyPrint config then Just (configPrettyPrintFunction config outputUnicode) else Nothing
       , formatConfigPrintTimes = configTimes config

--- a/hspec-core/test/Helper.hs
+++ b/hspec-core/test/Helper.hs
@@ -31,6 +31,8 @@ module Helper (
 , (</>)
 , mkLocation
 , workaroundForIssue19236
+
+, replace
 ) where
 
 import           Prelude ()
@@ -167,3 +169,8 @@ mkLocation file line column = Just (Location (workaroundForIssue19236 file) line
 #else
 mkLocation _ _ _ = Nothing
 #endif
+
+replace :: Eq a => a -> a -> [a] -> [a]
+replace x y xs = case break (== x) xs of
+  (ys, _: zs) -> ys ++ y : zs
+  _ -> xs

--- a/hspec-core/test/Test/Hspec/Core/Config/OptionsSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/Config/OptionsSpec.hs
@@ -90,6 +90,25 @@ spec = do
       it "sets configDiff to False" $ do
         configDiff <$> parseOptions [] Nothing [] ["--no-diff"] `shouldBe` Right False
 
+    context "with --diff-context" $ do
+      it "accepts 0" $ do
+        configDiffContext <$> parseOptions [] Nothing [] ["--diff-context=0"] `shouldBe` Right (Just 0)
+
+      it "accepts positive values" $ do
+        configDiffContext <$> parseOptions [] Nothing [] ["--diff-context=5"] `shouldBe` Right (Just 5)
+
+      it "rejects invalid values" $ do
+          let msg = "my-spec: invalid argument `foo' for `--diff-context'\nTry `my-spec --help' for more information.\n"
+          void (parseOptions [] Nothing [] ["--diff-context=foo"]) `shouldBe` Left (ExitFailure 1, msg)
+
+      context "with negative values" $ do
+        it "disables the option" $ do
+          configDiffContext <$> parseOptions [] Nothing [] ["--diff-context=-1"] `shouldBe` Right Nothing
+
+      context "with 'full'" $ do
+        it "disables the option" $ do
+          configDiffContext <$> parseOptions [] Nothing [] ["--diff-context=full"] `shouldBe` Right Nothing
+
     context "with --print-slow-items" $ do
       it "sets configPrintSlowItems to N" $ do
         configPrintSlowItems <$> parseOptions [] Nothing [] ["--print-slow-items=5"] `shouldBe` Right (Just 5)

--- a/hspec-core/test/Test/Hspec/Core/Formatters/DiffSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/Formatters/DiffSpec.hs
@@ -12,6 +12,86 @@ dropQuotes = init . tail
 
 spec :: Spec
 spec = do
+  describe "diff" $ do
+    let
+      enumerate name n = map ((name ++) . show) [1 .. n :: Int]
+      diff_ expected actual = diff (Just 2) (unlines expected) (unlines actual)
+
+    it "suppresses excessive diff output" $ do
+      let
+        expected = enumerate "foo" 99
+        actual = replace "foo50" "bar50" expected
+
+      diff_ expected actual `shouldBe` [
+          Omitted 47
+        , Both $ unlines [
+            "foo48"
+          , "foo49"
+          ]
+        , First  "foo50"
+        , Second "bar50"
+        , Both $ unlines [
+            ""
+          , "foo51"
+          , "foo52"
+          ]
+        , Omitted 47
+        ]
+
+    it "ensures that omitted sections are at least three lines in size" $ do
+      forAll (elements [1..20]) $ \ size -> do
+        let expected = enumerate "" size
+        forAll (elements expected) $ \ i -> do
+          let actual = replace i "bar" expected
+          [n | Omitted n <- diff_ expected actual] `shouldSatisfy` all (>= 3)
+
+    context "with modifications within a line" $ do
+        it "suppresses excessive diff output" $ do
+          let
+            expected = enumerate "foo " 99
+            actual = replace "foo 42" "foo 23" expected
+
+          diff_ expected actual `shouldBe` [
+              Omitted 39
+            , Both $ concat [
+                "foo 40\n"
+              , "foo 41\n"
+              , "foo "
+              ]
+            , First  "42"
+            , Second "23"
+            , Both $ concat [
+                "\n"
+              , "foo 43\n"
+              , "foo 44\n"
+              ]
+            , Omitted 55
+            ]
+
+    context "with modifications at start / end" $ do
+      it "suppresses excessive diff output" $ do
+        let
+          expected = enumerate "foo" 9
+          actual = replace "foo9" "bar9" $ replace "foo1" "bar1" expected
+
+        diff_ expected actual `shouldBe` [
+            First  "foo1"
+          , Second "bar1"
+          , Both $ unlines [
+              ""
+            , "foo2"
+            , "foo3"
+            ]
+          , Omitted 3
+          , Both $ unlines [
+              "foo7"
+            , "foo8"
+            ]
+          , First  "foo9"
+          , Second "bar9"
+          , Both "\n"
+          ]
+
   describe "partition" $ do
     context "with a single shown Char" $ do
       it "never partitions a character escape" $ do

--- a/hspec-core/test/Test/Hspec/Core/Formatters/InternalSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/Formatters/InternalSpec.hs
@@ -14,6 +14,7 @@ formatConfig = FormatConfig {
 , formatConfigReportProgress = False
 , formatConfigOutputUnicode = False
 , formatConfigUseDiff = True
+, formatConfigDiffContext = Just 3
 , formatConfigPrettyPrint = False
 , formatConfigPrettyPrintFunction = Nothing
 , formatConfigPrintTimes = False

--- a/hspec-core/test/Test/Hspec/Core/Formatters/V2Spec.hs
+++ b/hspec-core/test/Test/Hspec/Core/Formatters/V2Spec.hs
@@ -27,6 +27,7 @@ formatConfig = FormatConfig {
 , formatConfigReportProgress = False
 , formatConfigOutputUnicode = unicode
 , formatConfigUseDiff = True
+, formatConfigDiffContext = Just 3
 , formatConfigPrettyPrint = True
 , formatConfigPrettyPrintFunction = Just (H.configPrettyPrintFunction H.defaultConfig unicode)
 , formatConfigPrintTimes = False

--- a/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
@@ -510,6 +510,41 @@ spec = do
           , red ++ "        but got: " ++ reset ++ "23"
           ]
 
+    context "with --diff-context" $ do
+      it "suppresses excessive diff output" $ do
+        let
+          args = ["--seed=0", "--format=failed-examples", "--diff-context=1"]
+          expected = map show [1 .. 99 :: Int]
+          actual = replace "50" "foo" expected
+        r <- fmap (unlines . normalizeSummary . lines) . capture_ . ignoreExitCode . withArgs args . H.hspec . removeLocations $ do
+          H.it "foo" $ do
+            unlines actual `H.shouldBe` unlines expected
+        r `shouldBe` unlines [
+            ""
+          , "Failures:"
+          , ""
+          , "  1) foo"
+          , "       expected: @@ 48 lines omitted @@"
+          , "                 49"
+          , "                 50"
+          , "                 51"
+          , "                 @@ 48 lines omitted @@"
+          , "                 "
+          , "        but got: @@ 48 lines omitted @@"
+          , "                 49"
+          , "                 foo"
+          , "                 51"
+          , "                 @@ 48 lines omitted @@"
+          , "                 "
+          , ""
+          , "  To rerun use: --match \"/foo/\""
+          , ""
+          , "Randomized with seed 0"
+          , ""
+          , "Finished in 0.0000 seconds"
+          , "1 example, 1 failure"
+          ]
+
     context "with --print-slow-items" $ do
       it "prints slow items" $ do
         r <- captureLines . ignoreExitCode . withArgs ["--print-slow-items"] . H.hspec $ do


### PR DESCRIPTION
- [x] Add a flag to disable (`--diff-context=full`)
- [x] Suppress identical lines within the text, not only at the start/end
- [x] Never omit less than 3 lines

(close #449)

#### before:
![before](https://user-images.githubusercontent.com/461132/188746885-e99db4a5-0c91-4607-b162-4106b88e2730.png)
#### after (with #715):
![after](https://user-images.githubusercontent.com/461132/188746911-89c08763-e10d-49a2-9834-362d7a48862b.png)
#### after (without #715):
![after](https://user-images.githubusercontent.com/461132/188747324-d4317b22-f0bb-43b7-816e-c2835e377127.png)