### PR TITLE
Revert deprecation of Test.Hspec.Formatters and Test.Hspec.Core.Formatters

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,6 +1,9 @@
 ## Changes in next
   - Add `--fail-on`.  This subsums `--fail-on-focused` and `--fail-on-pending`.
   - Add `--fail-on=empty` (#650)
+  - Revert deprecation of `Test.Hspec.Formatters` and
+    `Test.Hspec.Core.Formatters`.  Instead the module documentation now says
+    that they are deprecated in favor of `Test.Hspec.Core.Formatters.V1`.
 
 ## Changes in 2.10.4
   - Make sure that whitespace-only diff output is colorized properly (#660)

--- a/hspec-core/src/Test/Hspec/Core/Formatters.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters.hs
@@ -1,4 +1,6 @@
+-- |
+-- Deprecated\: Use "Test.Hspec.Core.Formatters.V1" instead.
 module Test.Hspec.Core.Formatters
-{-# DEPRECATED "Use \"Test.Hspec.Core.Formatters.V1\" instead." #-}
+-- {-# DEPRECATED "Use \"Test.Hspec.Core.Formatters.V1\" instead." #-}
 (module V1) where
 import           Test.Hspec.Core.Formatters.V1 as V1

--- a/src/Test/Hspec/Formatters.hs
+++ b/src/Test/Hspec/Formatters.hs
@@ -1,5 +1,7 @@
+-- |
+-- Deprecated\: Use "Test.Hspec.Core.Formatters.V1" instead.
 module Test.Hspec.Formatters
-{-# DEPRECATED "Use \"Test.Hspec.Core.Formatters.V1\" instead." #-}
+-- {-# DEPRECATED "Use \"Test.Hspec.Core.Formatters.V1\" instead." #-}
 (module Test.Hspec.Core.Formatters.V1)
 where
 import           Test.Hspec.Core.Formatters.V1


### PR DESCRIPTION
Instead the module documentation now says that they are deprecated in favor of `Test.Hspec.Core.Formatters.V1`.

There is just too much code that will fail with `-Werror` otherwise.