### PR TITLE
Allow the use of an external diff program, add `--diff-command`

### DIFF
--- a/changes/514.md
+++ b/changes/514.md
@@ -1,0 +1,2 @@
+  - Allow the use of an external diff program.  This can e.g. be used by
+    setting: `HSPEC_DIFF_COMMAND="diff -u --color -L expected -L actual"`

--- a/hspec-core/help.txt
+++ b/hspec-core/help.txt
@@ -37,6 +37,8 @@ FORMATTER OPTIONS
            --[no-]diff             show colorized diffs
            --diff-context=N        output N lines of diff context (default: 3)
                                    use a value of 'full' to see the full context
+           --diff-command=CMD      use an external diff command
+                                   example: --diff-command="git diff"
            --[no-]pretty           try to pretty-print diff values
            --[no-]times            report times for individual spec items
            --print-cpu-time        include used CPU time in summary

--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -44,6 +44,7 @@ library
     , directory
     , filepath
     , hspec-expectations ==0.8.2.*
+    , process
     , quickcheck-io >=0.2.0
     , random
     , setenv

--- a/hspec-core/package.yaml
+++ b/hspec-core/package.yaml
@@ -39,6 +39,7 @@ dependencies:
   - call-stack >= 0.2.0
   - directory
   - filepath
+  - process
 
   - array # for Diff
 

--- a/hspec-core/src/Test/Hspec/Core/Format.hs
+++ b/hspec-core/src/Test/Hspec/Core/Format.hs
@@ -60,6 +60,7 @@ data FormatConfig = FormatConfig {
 , formatConfigOutputUnicode :: Bool
 , formatConfigUseDiff :: Bool
 , formatConfigDiffContext :: Maybe Int
+, formatConfigExternalDiff :: Maybe (String -> String -> IO ())
 , formatConfigPrettyPrint :: Bool -- ^ Deprecated: use `formatConfigPrettyPrintFunction` instead
 , formatConfigPrettyPrintFunction :: Maybe (String -> String -> (String, String))
 , formatConfigPrintTimes :: Bool

--- a/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
+++ b/hspec-core/src/Test/Hspec/Core/Formatters/Internal.hs
@@ -36,6 +36,7 @@ module Test.Hspec.Core.Formatters.Internal (
 
 , useDiff
 , diffContext
+, externalDiffAction
 , prettyPrint
 , prettyPrintFunction
 , extraChunk
@@ -118,6 +119,18 @@ useDiff = getConfig formatConfigUseDiff
 -- @since 2.10.6
 diffContext :: FormatM (Maybe Int)
 diffContext = getConfig formatConfigDiffContext
+
+-- | An action for printing diffs.
+--
+-- The action takes @expected@ and @actual@ as arguments.
+--
+-- When this is a `Just`-value then it should be used instead of any built-in
+-- diff implementation.  A `Just`-value also implies that `useDiff` returns
+-- `True`.
+--
+-- @since 2.10.6
+externalDiffAction :: FormatM (Maybe (String -> String -> IO ()))
+externalDiffAction = getConfig formatConfigExternalDiff
 
 -- | Return `True` if the user requested pretty diffs, `False` otherwise.
 prettyPrint :: FormatM Bool

--- a/hspec-core/src/Test/Hspec/Core/Runner.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner.hs
@@ -339,6 +339,7 @@ runEvalTree config spec = do
       , formatConfigOutputUnicode = outputUnicode
       , formatConfigUseDiff = configDiff config
       , formatConfigDiffContext = configDiffContext config
+      , formatConfigExternalDiff = if configDiff config then ($ configDiffContext config) <$> configExternalDiff config else Nothing
       , formatConfigPrettyPrint = configPrettyPrint config
       , formatConfigPrettyPrintFunction = if configPrettyPrint config then Just (configPrettyPrintFunction config outputUnicode) else Nothing
       , formatConfigPrintTimes = configTimes config

--- a/hspec-core/test/SpecHook.hs
+++ b/hspec-core/test/SpecHook.hs
@@ -1,7 +1,17 @@
-module SpecHook where
+module SpecHook (hook) where
 
 import           Prelude ()
 import           Helper
 
+import           System.Environment (getEnvironment)
+
+ignoreHspecConfig :: IO a -> IO a
+ignoreHspecConfig action = do
+  env <- getEnvironment
+  let filteredEnv = ("IGNORE_DOT_HSPEC", "yes") : filter p env
+  withEnvironment filteredEnv action
+  where
+    p (name, _value) = name == "COMSPEC" || name == "PATH"
+
 hook :: Spec -> Spec
-hook = aroundAll_ (withEnvironment [("IGNORE_DOT_HSPEC", "yes")])
+hook = aroundAll_ ignoreHspecConfig

--- a/hspec-core/test/Test/Hspec/Core/Config/OptionsSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/Config/OptionsSpec.hs
@@ -117,6 +117,10 @@ spec = do
         it "disables the option" $ do
           configDiffContext <$> parseOptions [] Nothing [] ["--diff-context=full"] `shouldBe` Right Nothing
 
+    context "with --diff-command=" $ do
+      it "sets configExternalDiff to Nothing" $ do
+        fmap (const ()) . configExternalDiff <$> parseOptions [] Nothing [] ["--diff-command="] `shouldBe` Right Nothing
+
     context "with --print-slow-items" $ do
       it "sets configPrintSlowItems to N" $ do
         configPrintSlowItems <$> parseOptions [] Nothing [] ["--print-slow-items=5"] `shouldBe` Right (Just 5)

--- a/hspec-core/test/Test/Hspec/Core/Formatters/InternalSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/Formatters/InternalSpec.hs
@@ -15,6 +15,7 @@ formatConfig = FormatConfig {
 , formatConfigOutputUnicode = False
 , formatConfigUseDiff = True
 , formatConfigDiffContext = Just 3
+, formatConfigExternalDiff = Nothing
 , formatConfigPrettyPrint = False
 , formatConfigPrettyPrintFunction = Nothing
 , formatConfigPrintTimes = False

--- a/hspec-core/test/Test/Hspec/Core/Formatters/V2Spec.hs
+++ b/hspec-core/test/Test/Hspec/Core/Formatters/V2Spec.hs
@@ -28,6 +28,7 @@ formatConfig = FormatConfig {
 , formatConfigOutputUnicode = unicode
 , formatConfigUseDiff = True
 , formatConfigDiffContext = Just 3
+, formatConfigExternalDiff = Nothing
 , formatConfigPrettyPrint = True
 , formatConfigPrettyPrintFunction = Just (H.configPrettyPrintFunction H.defaultConfig unicode)
 , formatConfigPrintTimes = False

--- a/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
@@ -545,6 +545,40 @@ spec = do
           , "1 example, 1 failure"
           ]
 
+    context "with --diff-command" $ do
+      it "uses an external diff command" $ do
+        let
+          args = ["--seed=0", "--format=failed-examples", "--diff-command", "diff -u -L expected -L actual"]
+          expected = map show [1 .. 99 :: Int]
+          actual = replace "50" "foo" expected
+        r <- fmap (unlines . normalizeSummary . lines) . capture_ . ignoreExitCode . withArgs args . H.hspec . removeLocations $ do
+          H.it "foo" $ do
+            unlines actual `H.shouldBe` unlines expected
+        r `shouldBe` unlines [
+            ""
+          , "Failures:"
+          , ""
+          , "  1) foo"
+          , "--- expected"
+          , "+++ actual"
+          , "@@ -47,7 +47,7 @@"
+          , " 47"
+          , " 48"
+          , " 49"
+          , "-50"
+          , "+foo"
+          , " 51"
+          , " 52"
+          , " 53"
+          , ""
+          , "  To rerun use: --match \"/foo/\""
+          , ""
+          , "Randomized with seed 0"
+          , ""
+          , "Finished in 0.0000 seconds"
+          , "1 example, 1 failure"
+          ]
+
     context "with --print-slow-items" $ do
       it "prints slow items" $ do
         r <- captureLines . ignoreExitCode . withArgs ["--print-slow-items"] . H.hspec $ do


### PR DESCRIPTION
(close #514)

#### Hspec's default diff with `:main`
![hspec-diff](https://user-images.githubusercontent.com/461132/189867582-feafc69b-8ddb-4379-a587-f9df687d1128.png)
#### GNU diff with `:main --diff-command "diff -u --color -L expected -L actual"`
![gnu-diff](https://user-images.githubusercontent.com/461132/189867594-267b96b2-9f48-42f7-b74b-f632e2daea7d.png)

#### `:main --diff-command "git diff"` with `diff-so-fancy`
![git-diff](https://user-images.githubusercontent.com/461132/189867597-032b00e5-ab70-4bed-b467-c41cb29c3f61.png)
