### PR TITLE
Add `xprop` and `fprop`, which use `xit` and `fit`

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,6 @@
+## Changes in 2.10.8 (TBD)
+  - Add `xprop` and `fprop`, which use `xit` and `fit`
+
 ## Changes in 2.10.7 (2022-12-03)
   - Do not depend on `ghc` for pretty-printing (#750, #752)
 

--- a/src/Test/Hspec/QuickCheck.hs
+++ b/src/Test/Hspec/QuickCheck.hs
@@ -10,6 +10,8 @@ module Test.Hspec.QuickCheck (
 
 -- * Shortcuts
 , prop
+, xprop
+, fprop
 ) where
 
 import           Test.Hspec
@@ -26,3 +28,27 @@ import           Test.Hspec.Core.QuickCheck
 -- >   ..
 prop :: (HasCallStack, Testable prop) => String -> prop -> Spec
 prop s = it s . property
+
+
+-- |
+-- > xprop ".." $
+-- >   ..
+--
+-- is a shortcut for
+--
+-- > xit ".." $ property $
+-- >   ..
+xprop :: (HasCallStack, Testable prop) => String -> prop -> Spec
+xprop s = xit s . property
+
+
+-- |
+-- > fprop ".." $
+-- >   ..
+--
+-- is a shortcut for
+--
+-- > fit ".." $ property $
+-- >   ..
+fprop :: (HasCallStack, Testable prop) => String -> prop -> Spec
+fprop s = fit s . property


### PR DESCRIPTION
I felt like these are missing. 

Feel free to close this PR if you don't think this helpers are needed.