### PR TITLE
Prevent deadlocks on unguarded exceptions in runner

### DIFF
--- a/changes/771.md
+++ b/changes/771.md
@@ -1,0 +1,1 @@
+  - Prevent deadlocks on unguarded exceptions in runner (#771)

--- a/hspec-core/src/Test/Hspec/Core/Example.hs
+++ b/hspec-core/src/Test/Hspec/Core/Example.hs
@@ -21,6 +21,7 @@ module Test.Hspec.Core.Example (
 , safeEvaluateExample
 -- END RE-EXPORTED from Test.Hspec.Core.Spec
 , safeEvaluateResultStatus
+, exceptionToResultStatus
 , toLocation
 ) where
 

--- a/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
@@ -699,6 +699,16 @@ spec = do
         H.it "foobar" throwException_
       `shouldReturn` H.Summary 1 1
 
+    it "handles unguarded exceptions in runner" $ do
+      let
+        throwExceptionThatIsNotGuardedBy_safeTry :: H.Item () -> H.Item ()
+        throwExceptionThatIsNotGuardedBy_safeTry item = item {
+          H.itemExample = \ _params _hook _progress -> throwIO DivideByZero
+        }
+      hspecResult_ $ H.mapSpecItem_ throwExceptionThatIsNotGuardedBy_safeTry $ do
+        H.it "foo" True
+      `shouldReturn` H.Summary 1 1
+
     it "uses the specdoc formatter by default" $ do
       _:r:_ <- captureLines . H.hspecResult $ do
         H.describe "Foo.Bar" $ do


### PR DESCRIPTION
The runner operates under the assumption that all exceptions from spec
items are handled and converted to `Result`s.  This is ensured by
`safeEvaluateExample`.

If a user violates this assumption by manually modifying a spec item
with `mapSpecItem_` and omitting proper exception handling then this can
lead to a deadlock.

This change addresses this by no longer relying on that assumption.
