### PR TITLE
Pretty-print improvements / fixes

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,12 @@
+## Changes in 2.10.9 (2023-01-13)
+  - Print error message on `-—fail-on=empty`
+  - Only fail on `-—fail-on=empty` if at least one spec item has been filtered
+  - Re-export more types from `Test.Hspec.Core.Runner`
+  - Fix a pretty-printing bug where `[]` would be pretty-printed as `""`
+  - Don't pretty-print if the expected and actual value would be equal after
+    pretty-printing
+  - Prevent deadlocks on unguarded exceptions in runner (#771)
+
 ## Changes in 2.10.8 (2022-12-19)
   - Add pretty-printing support for rational numbers
   - Force / evaluate exceptions recursively (#763)

--- a/changes/771.md
+++ b/changes/771.md
@@ -1,1 +1,0 @@
-  - Prevent deadlocks on unguarded exceptions in runner (#771)

--- a/changes/779.md
+++ b/changes/779.md
@@ -1,2 +1,0 @@
-  - Print error message on `-—fail-on=empty`
-  - Only fail on `-—fail-on=empty` if at least one spec item has been filtered

--- a/changes/export-modifyConfig.md
+++ b/changes/export-modifyConfig.md
@@ -1,1 +1,0 @@
-  - Re-export more types from `Test.Hspec.Core.Runner`

--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:             hspec-core
-version:          2.10.8
+version:          2.10.9
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2011-2023 Simon Hengel,

--- a/hspec-core/test/Test/Hspec/Core/Formatters/PrettySpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/Formatters/PrettySpec.hs
@@ -19,23 +19,53 @@ spec = do
         it "does not recover unicode" $ do
           pretty2 False (show "foo\955bar") (show "foo-bar") `shouldBe` ("\"foo\\955bar\"", "\"foo-bar\"")
 
+      context "when expected and actual would be equal after pretty-printing" $ do
+        it "returns the original values unmodified" $ do
+          pretty2 True (show "foo") (show "foo" <> "   ") `shouldBe` (show "foo", show "foo" <> "   ")
+
   describe "recoverString" $ do
-    it "parses back multi-line string literals" $ do
-      recoverString True (show "foo\nbar\nbaz\n") `shouldBe` Just "foo\nbar\nbaz\n"
+    it "recovers a string" $ do
+      recoverString (show "foo") `shouldBe` Just "foo"
 
-    it "does not parse back string literals that contain control characters" $ do
-      recoverString True (show "foo\n\tbar\nbaz\n") `shouldBe` Nothing
+    it "recovers the empty string" $ do
+      recoverString (show "") `shouldBe` Just ""
 
-    it "does not parse back string literals that span a single line" $ do
-      recoverString True (show "foo\n") `shouldBe` Nothing
+    it "does not recover a string with leading space" $ do
+      recoverString ("   " <> show "foo") `shouldBe` Nothing
+
+    it "does not recover a string with trailing space" $ do
+      recoverString (show "foo" <> "   ") `shouldBe` Nothing
+
+    it "does not recover an empty list" $ do
+      recoverString "[]" `shouldBe` Nothing
+
+  describe "recoverMultiLineString" $ do
+    let
+      multiLineString :: String
+      multiLineString = "foo\nbar\nbaz\n"
+
+    it "recovers multi-line string literals" $ do
+      recoverMultiLineString True (show multiLineString) `shouldBe` Just multiLineString
+
+    it "does not recover string literals that contain control characters" $ do
+      recoverMultiLineString True (show "foo\n\tbar\nbaz\n") `shouldBe` Nothing
+
+    it "does not recover string literals that span a single line" $ do
+      recoverMultiLineString True (show "foo\n") `shouldBe` Nothing
+
+    it "does not recover a string with trailing space" $ do
+      recoverMultiLineString True ("   " <> show multiLineString) `shouldBe` Nothing
+
+    it "does not recover a string with trailing space" $ do
+      recoverMultiLineString True (show multiLineString <> "   ") `shouldBe` Nothing
 
     context "when unicode is True" $ do
-      it "parses back string literals that contain unicode" $ do
-        recoverString True (show "foo\n\955\nbaz\n") `shouldBe` Just "foo\n\955\nbaz\n"
+      it "recovers string literals that contain unicode" $ do
+        recoverMultiLineString True (show "foo\n\955\nbaz\n") `shouldBe` Just "foo\n\955\nbaz\n"
 
     context "when unicode is False" $ do
-      it "does not parse back string literals that contain unicode" $ do
-        recoverString False (show "foo\n\955\nbaz\n") `shouldBe` Nothing
+      it "does not recover string literals that contain unicode" $ do
+        recoverMultiLineString False (show "foo\n\955\nbaz\n") `shouldBe` Nothing
 
   describe "pretty" $ do
     let person = Person "Joe" 23

--- a/hspec-discover/hspec-discover.cabal
+++ b/hspec-discover/hspec-discover.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:             hspec-discover
-version:          2.10.8
+version:          2.10.9
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2012-2023 Simon Hengel

--- a/hspec.cabal
+++ b/hspec.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:             hspec
-version:          2.10.8
+version:          2.10.9
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2011-2023 Simon Hengel,
@@ -45,8 +45,8 @@ library
   build-depends:
       QuickCheck >=2.12
     , base ==4.*
-    , hspec-core ==2.10.8
-    , hspec-discover ==2.10.8
+    , hspec-core ==2.10.9
+    , hspec-discover ==2.10.9
     , hspec-expectations ==0.8.2.*
   exposed-modules:
       Test.Hspec

--- a/version.yaml
+++ b/version.yaml
@@ -1,1 +1,1 @@
-&version 2.10.8
+&version 2.10.9


### PR DESCRIPTION
- Fix a bug where `[]` would be pretty-printed as `""`
- Don't pretty-print if the expected and actual value would be equal after pretty-printing