### PR TITLE
refactoring: Internally use types that more closely represent the domain

### DIFF
--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -5,9 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - main
+  merge_group:
   pull_request:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  merge_group:
   pull_request:
     branches:
       - main

--- a/hspec-core/src/Test/Hspec/Core/Compat.hs
+++ b/hspec-core/src/Test/Hspec/Core/Compat.hs
@@ -85,6 +85,10 @@ import qualified Text.ParserCombinators.ReadP as P
 import           Data.Ord (comparing)
 #endif
 
+#if MIN_VERSION_base(4,7,0)
+import           Data.Bool as Imports (bool)
+#endif
+
 import           Data.Typeable (tyConModule, tyConName)
 import           Control.Concurrent
 
@@ -168,6 +172,12 @@ guarded p a = if p a then pure a else empty
 sortOn :: Ord b => (a -> b) -> [a] -> [a]
 sortOn f =
   map snd . sortBy (comparing fst) . map (\x -> let y = f x in y `seq` (y, x))
+#endif
+
+#if !MIN_VERSION_base(4,7,0)
+bool :: a -> a -> Bool -> a
+bool f _ False = f
+bool _ t True  = t
 #endif
 
 #if !MIN_VERSION_base(4,11,0)

--- a/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
@@ -24,6 +24,7 @@ import           System.Console.ANSI
 import           Test.Hspec.Core.FailureReport (FailureReport(..))
 import qualified Test.Hspec.Expectations as H
 import qualified Test.Hspec.Core.Spec as H
+import           Test.Hspec.Core.Runner (UseColor(..), ProgressReporting(..))
 import qualified Test.Hspec.Core.Runner as H
 import           Test.Hspec.Core.Runner.Result
 import qualified Test.Hspec.Core.QuickCheck as H
@@ -764,35 +765,34 @@ spec = do
         high `shouldBe` j
 
   describe "colorOutputSupported" $ do
-
     context "without a terminal device" $ do
 
       let isTerminalDevice = return False
 
-      it "returns False" $ do
-        H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` (False, False)
+      it "disables color output" $ do
+        H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` ColorDisabled
 
       context "with GITHUB_ACTIONS=true" $ do
-        it "returns True" $ do
+        it "enable color output" $ do
           withEnvironment [("GITHUB_ACTIONS", "true")] $ do
-            H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` (False, True)
+            H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` ColorEnabled ProgressReportingDisabled
 
     context "with a terminal device" $ do
 
       let isTerminalDevice = return True
 
-      it "returns True" $ do
-        H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` (True, True)
+      it "enable color output" $ do
+        H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` ColorEnabled ProgressReportingEnabled
 
       context "with BUILDKITE=true" $ do
         it "disables progress reporting" $ do
           withEnvironment [("BUILDKITE", "true")] $ do
-            H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` (False, True)
+            H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` ColorEnabled ProgressReportingDisabled
 
       context "when NO_COLOR is set" $ do
-        it "returns False" $ do
+        it "disables color output" $ do
           withEnvironment [("NO_COLOR", "yes")] $ do
-            H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` (False, False)
+            H.colorOutputSupported H.ColorAuto isTerminalDevice `shouldReturn` ColorDisabled
 
   describe "unicodeOutputSupported" $ do
     context "with UnicodeAlways" $ do


### PR DESCRIPTION
(in `Test.Hspec.Core.Runner`)