### PR TITLE
Don't crash when home directories are unsupported

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Config.hs
+++ b/hspec-core/src/Test/Hspec/Core/Config.hs
@@ -18,6 +18,7 @@ module Test.Hspec.Core.Config (
 import           Prelude ()
 import           Test.Hspec.Core.Compat
 
+import           GHC.IO.Exception (IOErrorType(UnsupportedOperation))
 import           System.IO
 import           System.IO.Error
 import           System.Exit
@@ -148,10 +149,13 @@ readConfigFiles = do
 
 readGlobalConfigFile :: IO (Maybe ConfigFile)
 readGlobalConfigFile = do
-  mHome <- tryJust (guard . isDoesNotExistError) getHomeDirectory
+  mHome <- tryJust (guard . isPotentialHomeDirError) getHomeDirectory
   case mHome of
     Left _ -> return Nothing
     Right home -> readConfigFile (home </> ".hspec")
+  where
+    isPotentialHomeDirError e =
+      isDoesNotExistError e || ioeGetErrorType e == UnsupportedOperation
 
 readLocalConfigFile :: IO (Maybe ConfigFile)
 readLocalConfigFile = do


### PR DESCRIPTION
From the [`getHomeDirectory` Haddocks](https://hackage.haskell.org/package/directory-1.3.8.1/docs/System-Directory.html#v:getHomeDirectory):

> The operation may fail with:
>
> - `UnsupportedOperation` The operating system has no notion of home directory.
> - [`isDoesNotExistError`](https://hackage.haskell.org/package/base-4.16.3.0/docs/System-IO-Error.html#v:isDoesNotExistError) The home directory for the current user does not exist, or cannot be found.

The motivating example for this PR is the WASM backend in GHC 9.6, as [WASI](https://wasi.dev/) does not support home directories.