### PR TITLE
Suppresses informational QuickCheck output when `chatty` is `False`

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,7 @@
+## Changes in 2.11.3 (2023-07-10)
+  - Suppress informational output from QuickCheck when
+    `Test.QuickCheck.Args.chatty` is `False` (#840)
+
 ## Changes in 2.11.2 (2023-07-06)
   - Add `--expert` mode
 

--- a/changes/qc-chatty.md
+++ b/changes/qc-chatty.md
@@ -1,0 +1,2 @@
+  - Suppress informational output from QuickCheck when
+    `Test.QuickCheck.Args.chatty` is `False` (#840)

--- a/changes/qc-chatty.md
+++ b/changes/qc-chatty.md
@@ -1,2 +1,0 @@
-  - Suppress informational output from QuickCheck when
-    `Test.QuickCheck.Args.chatty` is `False` (#840)

--- a/doc/_site/options.html
+++ b/doc/_site/options.html
@@ -201,6 +201,7 @@ FORMATTER OPTIONS
            --[no-]times            report times for individual spec items
            --print-cpu-time        include used CPU time in summary
   -p[N]    --print-slow-items[=N]  print the N slowest spec items (default: 10)
+           --[no-]expert           be less verbose
 
 OPTIONS FOR QUICKCHECK
   -a N  --qc-max-success=N  maximum number of successful tests before a

--- a/hspec-api/hspec-api.cabal
+++ b/hspec-api/hspec-api.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           hspec-api
-version:        2.11.2
+version:        2.11.3
 synopsis:       A Testing Framework for Haskell
 description:    This package provides a stable API that can be used to extend Hspec's functionality.
 category:       Testing
@@ -39,7 +39,7 @@ library
   ghc-options: -Wall
   build-depends:
       base ==4.*
-    , hspec-core ==2.11.2
+    , hspec-core ==2.11.3
     , transformers
   default-language: Haskell2010
 
@@ -62,6 +62,6 @@ test-suite spec
       base ==4.*
     , hspec ==2.*
     , hspec-api
-    , hspec-core ==2.11.2
+    , hspec-core ==2.11.3
     , transformers
   default-language: Haskell2010

--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:             hspec-core
-version:          2.11.2
+version:          2.11.3
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2011-2023 Simon Hengel,
@@ -129,7 +129,7 @@ test-suite spec
     , filepath
     , haskell-lexer
     , hspec-expectations ==0.8.3.*
-    , hspec-meta ==2.11.2
+    , hspec-meta ==2.11.3
     , process
     , quickcheck-io >=0.2.0
     , random

--- a/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
@@ -717,6 +717,33 @@ spec = do
       it "uses specified discard ratio to QuickCheck properties" $ do
         ["--qc-max-discard", "23"] `shouldUseArgs` (QC.maxDiscardRatio, 23)
 
+    describe "Test.QuickCheck.Args.chatty" $ do
+      let
+        setChatty value args = args { chatty = value }
+        withChatty value = hspecCapture [] .  H.modifyArgs (setChatty value) $ do
+          H.it "foo" $ property True
+
+      context "when True" $ do
+        it "includes informational output" $ do
+          withChatty True `shouldReturn` unlines [
+              ""
+            , "foo [✔]"
+            , "  +++ OK, passed 1 test."
+            , ""
+            , "Finished in 0.0000 seconds"
+            , "1 example, 0 failures"
+            ]
+
+      context "when False" $ do
+        it "suppresses informational output" $ do
+          withChatty False `shouldReturn` unlines [
+              ""
+            , "foo [✔]"
+            , ""
+            , "Finished in 0.0000 seconds"
+            , "1 example, 0 failures"
+            ]
+
     context "with --seed" $ do
       it "uses specified seed" $ do
         r <- runPropFoo ["--seed", "42"]

--- a/hspec-discover/hspec-discover.cabal
+++ b/hspec-discover/hspec-discover.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:             hspec-discover
-version:          2.11.2
+version:          2.11.3
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2012-2023 Simon Hengel
@@ -77,7 +77,7 @@ test-suite spec
     , directory
     , filepath
     , hspec-discover
-    , hspec-meta ==2.11.2
+    , hspec-meta ==2.11.3
     , mockery >=0.3.5
   build-tool-depends:
       hspec-meta:hspec-meta-discover

--- a/hspec-meta/hspec-meta.cabal
+++ b/hspec-meta/hspec-meta.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           hspec-meta
-version:        2.11.2
+version:        2.11.3
 synopsis:       A version of Hspec which is used to test Hspec itself
 description:    A stable version of Hspec which is used to test the
                 in-development version of Hspec.

--- a/hspec.cabal
+++ b/hspec.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:             hspec
-version:          2.11.2
+version:          2.11.3
 license:          MIT
 license-file:     LICENSE
 copyright:        (c) 2011-2023 Simon Hengel,
@@ -45,8 +45,8 @@ library
   build-depends:
       QuickCheck >=2.12
     , base ==4.*
-    , hspec-core ==2.11.2
-    , hspec-discover ==2.11.2
+    , hspec-core ==2.11.3
+    , hspec-discover ==2.11.3
     , hspec-expectations ==0.8.3.*
   exposed-modules:
       Test.Hspec

--- a/version.yaml
+++ b/version.yaml
@@ -1,4 +1,4 @@
-version: &version 2.11.2
+version: &version 2.11.3
 synopsis: A Testing Framework for Haskell
 maintainer: Simon Hengel <sol@typeful.net>
 category: Testing


### PR DESCRIPTION
(fixes #840)