### PR TITLE
Do not symlink to symlinks

### DIFF
--- a/hspec-meta/vendor
+++ b/hspec-meta/vendor
@@ -1,1 +1,1 @@
-hspec-core/vendor/
+../hspec-core/vendor/


### PR DESCRIPTION
Right now the following `stack.yaml`:

```
extra-deps:
  - git: https://github.com/hspec/hspec
    commit: c38a03dd8c23b3d73ad2685e89ff3b0a73a844a6
```

Yields:
```
Cloning c38a03dd8c23b3d73ad2685e89ff3b0a73a844a6 from https://github.com/hspec/hspec
Error: [S-760]
Unsupported tarball from /dev/shm/drlkf/with-repo-archive2139961/foo.tar: Symbolic link dest not found from hspec-meta/vendor to hspec-core/vendor/, looking for hspec-meta/hspec-core/vendor.
This may indicate that the source is a git archive which uses git-annex.
See https://github.com/commercialhaskell/stack/issues/4579 for further information.
```

See also: https://github.com/commercialhaskell/stack/issues/5004