### PR TITLE
Use CPS WriterT

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Spec/Monad.hs
+++ b/hspec-core/src/Test/Hspec/Core/Spec/Monad.hs
@@ -25,7 +25,7 @@ import           Test.Hspec.Core.Compat
 
 import           Control.Monad.IO.Class (liftIO)
 import           Control.Monad.Trans.Reader
-import           Control.Monad.Trans.Writer
+import           Control.Monad.Trans.Writer.CPS
 
 import           Test.Hspec.Core.Example
 import           Test.Hspec.Core.Tree
@@ -87,4 +87,4 @@ newtype Env = Env {
 }
 
 withEnv :: (Env -> Env) -> SpecM a r -> SpecM a r
-withEnv f = SpecM . WriterT . local f . runWriterT . unSpecM
+withEnv f = SpecM . writerT . local f . runWriterT . unSpecM


### PR DESCRIPTION
This PR changes the `SpecM` type to use `Control.Monad.Trans.Writer.CPS`.

`WriterT` is a known space leak, and the CPS `WriterT` does better. We have an enormous amount of tests and the time to boot the test suite is an issue. I suspect `WriterT` to be a problem, so I'm making this PR to easily test in our codebase. 

Running `time cabal test all` in repo consistently takes ~2.0-2.1s with this patch, and about 2.2-2.3 without. 

Running our tests without this patch with `--dry-run +RTS -t`:

```
Finished in 1.3739 seconds
23919 examples, 0 failures

<<ghc: 10623754648 bytes, 1907 GCs, 101038540/409635304 avg/max bytes residency (18 samples), 1266M in use, 0.005 INIT (0.003 elapsed), 5.455 MUT (4.288 elapsed), 3.865 GC (1.370 elapsed) :ghc>>
```

With this patch: 

```
Finished in 1.3193 seconds
23919 examples, 0 failures

<<ghc: 13145304224 bytes, 2283 GCs, 120833353/515563864 avg/max bytes residency (18 samples), 1170M in use, 0.007 INIT (0.003 elapsed), 6.033 MUT (4.635 elapsed), 4.612 GC (1.640 elapsed) :ghc>>
```

The improvement is more slight than I expected. More memory in use, too. Probably not worthwhile to pursue further.