### PR TITLE
Add extensions API

### DIFF
--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -58,6 +58,7 @@ library
       Test.Hspec.Core.Extension.Item
       Test.Hspec.Core.Extension.Spec
       Test.Hspec.Core.Extension.Tree
+      Test.Hspec.Core.Extension.Option
       Test.Hspec.Core.Extension.Config
       Test.Hspec.Core.Spec
       Test.Hspec.Core.Hooks
@@ -169,6 +170,7 @@ test-suite spec
       Test.Hspec.Core.Extension.Config
       Test.Hspec.Core.Extension.Config.Type
       Test.Hspec.Core.Extension.Item
+      Test.Hspec.Core.Extension.Option
       Test.Hspec.Core.Extension.Spec
       Test.Hspec.Core.Extension.Tree
       Test.Hspec.Core.FailureReport

--- a/hspec-core/package.yaml
+++ b/hspec-core/package.yaml
@@ -54,6 +54,7 @@ library:
     - Test.Hspec.Core.Extension.Item
     - Test.Hspec.Core.Extension.Spec
     - Test.Hspec.Core.Extension.Tree
+    - Test.Hspec.Core.Extension.Option
     - Test.Hspec.Core.Extension.Config
     - Test.Hspec.Core.Spec
     - Test.Hspec.Core.Hooks

--- a/hspec-core/src/GetOpt/Declarative/Types.hs
+++ b/hspec-core/src/GetOpt/Declarative/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 module GetOpt.Declarative.Types where
 
 import           Prelude ()
@@ -17,18 +16,3 @@ data OptionSetter config =
   | Flag (Bool -> config -> config)
   | OptArg String (Maybe String -> config -> Maybe config)
   | Arg String (String -> config -> Maybe config)
-
-mapOption :: (b -> a) -> (a -> b) -> Option a -> Option b
-mapOption from to option = option {
-  optionSetter = mapOptionSetter from to $ optionSetter option
-}
-
-mapOptionSetter :: (b -> a) -> (a -> b) -> OptionSetter a -> OptionSetter b
-mapOptionSetter from to = \ case
-  NoArg f -> NoArg $ lift f
-  Flag f -> Flag $ lift . f
-  OptArg name f -> OptArg name $ liftF . f
-  Arg name f -> Arg name $ liftF . f
-  where
-    lift f = to . f . from
-    liftF f = fmap to . f . from

--- a/hspec-core/src/Test/Hspec/Core/Extension.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension.hs
@@ -79,7 +79,7 @@ import           Test.Hspec.Core.Compat
 import qualified Data.CallStack as CallStack
 
 import qualified GetOpt.Declarative as Declarative
-import           Test.Hspec.Core.Spec (SpecM, SpecWith, runIO)
+import           Test.Hspec.Core.Spec (SpecM, SpecWith, runIO, modifyConfig)
 import qualified Test.Hspec.Core.Spec as Core
 import qualified Test.Hspec.Core.Config.Definition as Core
 
@@ -97,11 +97,7 @@ registerOptions = Core.modifyConfig . Core.addExtensionOptions section . map lif
     package = maybe "main" (CallStack.srcLocPackage . snd) CallStack.callSite
 
     liftOption :: Option -> Declarative.Option Core.Config
-    liftOption = Declarative.mapOption Config.from Config.to . Config.unOption
-
-
-modifyConfig :: (Config -> Config) -> SpecWith a
-modifyConfig f = Core.modifyConfig (Config.to . f . Config.from)
+    liftOption = Config.unOption
 
 {- |
 Register a transformation that transforms the spec tree in phase 3.

--- a/hspec-core/src/Test/Hspec/Core/Extension.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension.hs
@@ -1,5 +1,6 @@
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
 -- | Stability: unstable
-module Test.Hspec.Core.Extension (
+module Test.Hspec.Core.Extension {-# WARNING "This API is experimental." #-} (
 -- * Lifecycle of a test run
 {- |
 A test run goes through four distinct phases:

--- a/hspec-core/src/Test/Hspec/Core/Extension/Config.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Config.hs
@@ -1,4 +1,5 @@
-module Test.Hspec.Core.Extension.Config (
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+module Test.Hspec.Core.Extension.Config {-# WARNING "This API is experimental." #-} (
 -- * Types
   Config(..)
 , Path

--- a/hspec-core/src/Test/Hspec/Core/Extension/Config/Type.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Config/Type.hs
@@ -1,11 +1,7 @@
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 module Test.Hspec.Core.Extension.Config.Type (
   Option(..)
 , Config(..)
-, to
-, from
 
 , setAnnotation
 , getAnnotation
@@ -21,161 +17,19 @@ import           Test.Hspec.Core.Compat
 
 import qualified GetOpt.Declarative as Declarative
 
-import           Test.Hspec.Core.Format
-import           Test.Hspec.Core.Config.Definition (ColorMode(..), UnicodeMode(..))
+import           Test.Hspec.Core.Config.Definition (Config(..))
 import qualified Test.Hspec.Core.Config.Definition as Core
-import           Test.Hspec.Core.Annotations (Annotations)
 import qualified Test.Hspec.Core.Annotations as Annotations
 
 import           Test.Hspec.Core.Extension.Tree (SpecTree)
 
 newtype Option = Option { unOption :: Declarative.Option Config }
 
-data Config = Config {
-  ignoreConfigFile :: Bool
-, dryRun :: Bool
-, focusedOnly :: Bool
-, failOnEmpty :: Bool
-, failOnFocused :: Bool
-, failOnPending :: Bool
-, failOnEmptyDescription :: Bool
-, printSlowItems :: Maybe Int
-, printCpuTime :: Bool
-, failFast :: Bool
-, randomize :: Bool
-, seed :: Maybe Integer
-, failureReport :: Maybe FilePath
-, rerun :: Bool
-, rerunAllOnSuccess :: Bool
-
--- |
--- A predicate that is used to filter the spec before it is run.  Only examples
--- that satisfy the predicate are run.
-, filterPredicate :: Maybe (Path -> Bool)
-, skipPredicate :: Maybe (Path -> Bool)
-, quickCheckMaxSuccess :: Maybe Int
-, quickCheckMaxDiscardRatio :: Maybe Int
-, quickCheckMaxSize :: Maybe Int
-, quickCheckMaxShrinks :: Maybe Int
-, smallCheckDepth :: Maybe Int
-, colorMode :: ColorMode
-, unicodeMode :: UnicodeMode
-, diff :: Bool
-, diffContext :: Maybe Int
-
--- |
--- An action that is used to print diffs.  The first argument is the value of
--- `configDiffContext`.  The remaining two arguments are the @expected@ and
--- @actual@ value.
-, externalDiff :: Maybe (Maybe Int -> String -> String -> IO ())
-
-, prettyPrint :: Bool
-, prettyPrintFunction :: Bool -> String -> String -> (String, String)
-, formatException :: SomeException -> String
-, times :: Bool
-, expertMode :: Bool
-, htmlOutput :: Bool
-, concurrentJobs :: Maybe Int
-, annotations :: Annotations
-}
-
-to :: Config -> Core.Config
-to Config{..} = Core.Config {
-  configIgnoreConfigFile = ignoreConfigFile
-, configDryRun = dryRun
-, configFocusedOnly = focusedOnly
-, configFailOnEmpty = failOnEmpty
-, configFailOnFocused = failOnFocused
-, configFailOnPending = failOnPending
-, configFailOnEmptyDescription = failOnEmptyDescription
-, configPrintSlowItems = printSlowItems
-, configPrintCpuTime = printCpuTime
-, configFailFast = failFast
-, configRandomize = randomize
-, configSeed = seed
-, configFailureReport = failureReport
-, configRerun = rerun
-, configRerunAllOnSuccess = rerunAllOnSuccess
-, configFilterPredicate = filterPredicate
-, configSkipPredicate = skipPredicate
-, configQuickCheckMaxSuccess = quickCheckMaxSuccess
-, configQuickCheckMaxDiscardRatio = quickCheckMaxDiscardRatio
-, configQuickCheckMaxSize = quickCheckMaxSize
-, configQuickCheckMaxShrinks = quickCheckMaxShrinks
-, configSmallCheckDepth = smallCheckDepth
-, configColorMode = colorMode
-, configUnicodeMode = unicodeMode
-, configDiff = diff
-, configDiffContext = diffContext
-, configExternalDiff = externalDiff
-, configPrettyPrint = prettyPrint
-, configPrettyPrintFunction = prettyPrintFunction
-, configFormatException = formatException
-, configTimes = times
-, configExpertMode = expertMode
-, configAvailableFormatters = availableFormatters
-, configFormat = format
-, configHtmlOutput = htmlOutput
-, configConcurrentJobs = concurrentJobs
-, configAnnotations = annotations
-
-, configQuickCheckSeed = Nothing
-, configFormatter = Nothing
-} where
-    Formatters availableFormatters format = getFormatters annotations
-
-from :: Core.Config -> Config
-from config@Core.Config{..} = Config{
-  ignoreConfigFile = configIgnoreConfigFile
-, dryRun = configDryRun
-, focusedOnly = configFocusedOnly
-, failOnEmpty = configFailOnEmpty
-, failOnFocused = configFailOnFocused
-, failOnPending = configFailOnPending
-, failOnEmptyDescription = configFailOnEmptyDescription
-, printSlowItems = configPrintSlowItems
-, printCpuTime = configPrintCpuTime
-, failFast = configFailFast
-, randomize = configRandomize
-, seed = Core.getSeed config
-, failureReport = configFailureReport
-, rerun = configRerun
-, rerunAllOnSuccess = configRerunAllOnSuccess
-, filterPredicate = configFilterPredicate
-, skipPredicate = configSkipPredicate
-, quickCheckMaxSuccess = configQuickCheckMaxSuccess
-, quickCheckMaxDiscardRatio = configQuickCheckMaxDiscardRatio
-, quickCheckMaxSize = configQuickCheckMaxSize
-, quickCheckMaxShrinks = configQuickCheckMaxShrinks
-, smallCheckDepth = configSmallCheckDepth
-, colorMode = configColorMode
-, unicodeMode = configUnicodeMode
-, diff = configDiff
-, diffContext = configDiffContext
-, externalDiff = configExternalDiff
-, prettyPrint = configPrettyPrint
-, prettyPrintFunction = configPrettyPrintFunction
-, formatException = configFormatException
-, times = configTimes
-, expertMode = configExpertMode
-, htmlOutput = configHtmlOutput
-, concurrentJobs = configConcurrentJobs
-, annotations = setFormatters (Formatters configAvailableFormatters (Core.getFormatter config)) configAnnotations
-}
-
-data Formatters = Formatters [(String, FormatConfig -> IO Format)] (Maybe (FormatConfig -> IO Format))
-
-getFormatters :: Annotations -> Formatters
-getFormatters = fromMaybe (Formatters [] Nothing) . Annotations.getValue
-
-setFormatters :: Formatters -> Annotations -> Annotations
-setFormatters = Annotations.setValue
-
 setAnnotation :: Typeable value => value -> Config -> Config
-setAnnotation value config = config { annotations = Annotations.setValue value $ annotations config }
+setAnnotation value config = config { configAnnotations = Annotations.setValue value $ configAnnotations config }
 
 getAnnotation :: Typeable value => Config -> Maybe value
-getAnnotation = Annotations.getValue . annotations
+getAnnotation = Annotations.getValue . configAnnotations
 
 newtype SpecTransformation = SpecTransformation { unSpecTransformation :: Config -> [SpecTree] -> [SpecTree] }
 
@@ -186,4 +40,4 @@ getSpecTransformation :: Config -> Config -> [SpecTree] -> [SpecTree]
 getSpecTransformation = maybe (\ _ -> id) unSpecTransformation . getAnnotation
 
 applySpecTransformation :: Core.Config -> [SpecTree] -> [SpecTree]
-applySpecTransformation (from -> config) = getSpecTransformation config config
+applySpecTransformation config = getSpecTransformation config config

--- a/hspec-core/src/Test/Hspec/Core/Extension/Config/Type.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Config/Type.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 module Test.Hspec.Core.Extension.Config.Type (
-  Config(..)
+  Option(..)
+, Config(..)
 , to
 , from
 
@@ -18,6 +19,8 @@ module Test.Hspec.Core.Extension.Config.Type (
 import           Prelude ()
 import           Test.Hspec.Core.Compat
 
+import qualified GetOpt.Declarative as Declarative
+
 import           Test.Hspec.Core.Format
 import           Test.Hspec.Core.Config.Definition (ColorMode(..), UnicodeMode(..))
 import qualified Test.Hspec.Core.Config.Definition as Core
@@ -25,6 +28,8 @@ import           Test.Hspec.Core.Annotations (Annotations)
 import qualified Test.Hspec.Core.Annotations as Annotations
 
 import           Test.Hspec.Core.Extension.Tree (SpecTree)
+
+newtype Option = Option { unOption :: Declarative.Option Config }
 
 data Config = Config {
   ignoreConfigFile :: Bool

--- a/hspec-core/src/Test/Hspec/Core/Extension/Item.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Item.hs
@@ -1,4 +1,4 @@
-module Test.Hspec.Core.Extension.Item (
+module Test.Hspec.Core.Extension.Item {-# WARNING "This API is experimental." #-} (
 -- * Types
   Item(..)
 , Location(..)

--- a/hspec-core/src/Test/Hspec/Core/Extension/Option.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Option.hs
@@ -1,0 +1,27 @@
+module Test.Hspec.Core.Extension.Option (
+  Option
+, flag
+, argument
+, noArgument
+, optionalArgument
+) where
+
+import           Prelude ()
+import           Test.Hspec.Core.Compat
+
+import qualified GetOpt.Declarative as Declarative
+import qualified Test.Hspec.Core.Config.Definition as Core
+
+import           Test.Hspec.Core.Extension.Config.Type (Option(..), Config)
+
+flag :: String -> (Bool -> Config -> Config) -> String -> Option
+flag name setter = Option . Core.flag name setter
+
+argument :: String -> String -> (String -> Config -> Maybe Config) -> String -> Option
+argument name argumentName setter = Option . Core.option name (Declarative.Arg argumentName setter)
+
+optionalArgument :: String -> String -> (Maybe String -> Config -> Maybe Config) -> String -> Option
+optionalArgument name argumentName setter = Option . Core.option name (Declarative.OptArg argumentName setter)
+
+noArgument :: String -> (Config -> Config) -> String -> Option
+noArgument name setter help = Option $ Declarative.Option name Nothing (Declarative.NoArg setter) help False

--- a/hspec-core/src/Test/Hspec/Core/Extension/Option.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Option.hs
@@ -1,4 +1,4 @@
-module Test.Hspec.Core.Extension.Option (
+module Test.Hspec.Core.Extension.Option {-# WARNING "This API is experimental." #-} (
   Option
 , flag
 , argument

--- a/hspec-core/src/Test/Hspec/Core/Extension/Spec.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Spec.hs
@@ -1,4 +1,4 @@
-module Test.Hspec.Core.Extension.Spec (
+module Test.Hspec.Core.Extension.Spec {-# WARNING "This API is experimental." #-} (
   mapItems
 ) where
 

--- a/hspec-core/src/Test/Hspec/Core/Extension/Tree.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Tree.hs
@@ -1,4 +1,4 @@
-module Test.Hspec.Core.Extension.Tree (
+module Test.Hspec.Core.Extension.Tree {-# WARNING "This API is experimental." #-} (
   SpecTree
 , mapItems
 , filterItems

--- a/hspec-core/src/Test/Hspec/Core/Extension/Tree.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Tree.hs
@@ -13,7 +13,7 @@ import qualified Test.Hspec.Core.Spec as Core
 type SpecTree = Core.SpecTree ()
 
 mapItems :: (Item () -> Item ()) -> [SpecTree] -> [SpecTree]
-mapItems = bimapForest id
+mapItems = map . fmap
 
 filterItems :: (Item () -> Bool) -> [SpecTree] -> [SpecTree]
 filterItems = filterForest

--- a/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
@@ -27,6 +27,7 @@ import qualified Test.QuickCheck as QC
 import qualified Test.Hspec.Core.Hooks as H
 
 import           Test.Hspec.Core.Formatters.Pretty.ParserSpec (Person(..))
+import           Test.Hspec.Core.Extension ()
 
 runPropFoo :: [String] -> IO String
 runPropFoo args = unlines . normalizeSummary . lines <$> do

--- a/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/hspec-meta/hspec-meta.cabal
+++ b/hspec-meta/hspec-meta.cabal
@@ -56,6 +56,7 @@ library
       Test.Hspec.Core.Extension.Config
       Test.Hspec.Core.Extension.Config.Type
       Test.Hspec.Core.Extension.Item
+      Test.Hspec.Core.Extension.Option
       Test.Hspec.Core.Extension.Spec
       Test.Hspec.Core.Extension.Tree
       Test.Hspec.Core.FailureReport


### PR DESCRIPTION
This PR adds an extension API that can be used to extend Hspec with additional functionality without the need to modify `hspec-core`.

An example extension that addresses https://github.com/hspec/hspec/issues/338:

```haskell
module Test.Hspec.CI (use, only) where

import System.Environment

import Test.Hspec.Core.Extension
import Test.Hspec.Core.Extension.Item qualified as Item
import Test.Hspec.Core.Extension.Spec qualified as Spec
import Test.Hspec.Core.Extension.Tree qualified as Tree
import Test.Hspec.Core.Extension.Config qualified as Config

-- |
-- Do not run the spec items of the given subtree by default; execute them only
-- when the environment variable @CI@ is set.
--
-- It is idiomatic to use this in combination with `>>>`:
--
-- @
-- import Control.Arrow ((>>>))
-- import Test.Hspec
-- import qualified Test.Hspec.CI as CI
--
-- spec :: Spec
-- spec = do
--   describe ".." $ do
--     it ".." >>> CI.only $ do
--       ..
-- @
only :: SpecWith a -> SpecWith a
only = Spec.mapItems setCiOnly

data CiOnly = CiOnly

setCiOnly :: Item a -> Item a
setCiOnly = Item.setAnnotation CiOnly

getCiOnly :: Item a -> Maybe CiOnly
getCiOnly = Item.getAnnotation

newtype CiFlag = CI Bool

setCiFlag :: Bool -> Config -> Config
setCiFlag = Config.setAnnotation . CI

getCiFlag :: Config -> CiFlag
getCiFlag = fromMaybe (CI False) . Config.getAnnotation

use :: SpecWith a
use = do
  runIO (lookupEnv "CI") >>= \ case
    Nothing -> pass
    Just _ -> modifyConfig (setCiFlag True)
  registerOption $ flag "ci" setCiFlag "include itmes that are marked as \"CI only\""
  registerTransformation applyCiOnly

applyCiOnly :: Config -> [SpecTree] -> [SpecTree]
applyCiOnly config = case getCiFlag config of
  CI True -> id
  CI False -> Tree.mapItems $ \ item -> case getCiOnly item of
    Nothing -> item
    Just CiOnly -> Item.pendingWith message item
  where
    message = unlines [
        "This item is marked as \"CI only\" and excluded by default."
      , "Use `--ci' to include this item."
      ]
```