### PR TITLE
Add do in 2nd test for consistency

### DIFF
--- a/doc/_includes/Example.hs
+++ b/doc/_includes/Example.hs
@@ -8,7 +8,7 @@ main = hspec $ do
     it "returns the first element of a list" $ do
       head [23 ..] `shouldBe` (23 :: Int)
 
-    it "returns the first element of an *arbitrary* list" $
+    it "returns the first element of an *arbitrary* list" $ do
       property $ \x xs -> head (x:xs) == (x :: Int)
 
     it "throws an exception if used with an empty list" $ do


### PR DESCRIPTION
Hello and thank you for creating hspec!

As a new user of hspec, I noticed that the second example test doesn't have a `do` at the end. I know the `do` isn't necessary there, but it's also not necessary at the end of any of the tests. Therefore, I propose to make things consistent by adding a `do` at the end of the second test. 

Thank you.