### PR TITLE
Make Hspec extensible

### DIFF
--- a/api/Test.Hspec.Runner
+++ b/api/Test.Hspec.Runner
@@ -43,6 +43,7 @@ data Config = Config
   configFormatter :: Maybe hspec-core:Test.Hspec.Core.Formatters.V1.Monad.Formatter
   configHtmlOutput :: Bool
   configConcurrentJobs :: Maybe Int
+  configAnnotations :: hspec-core:Test.Hspec.Core.Annotations.Annotations
 type Path :: *
 type Path = ([String], String)
 type ResultItem :: *

--- a/hspec-api/api/Test.Hspec.Api.Format.V1
+++ b/hspec-api/api/Test.Hspec.Api.Format.V1
@@ -68,6 +68,7 @@ data Config = hspec-core:Test.Hspec.Core.Config.Definition.Config
   hspec-core:Test.Hspec.Core.Config.Definition.configFormatter :: Maybe hspec-core:Test.Hspec.Core.Formatters.V1.Monad.Formatter
   hspec-core:Test.Hspec.Core.Config.Definition.configHtmlOutput :: Bool
   hspec-core:Test.Hspec.Core.Config.Definition.configConcurrentJobs :: Maybe Int
+  hspec-core:Test.Hspec.Core.Config.Definition.configAnnotations :: hspec-core:Test.Hspec.Core.Annotations.Annotations
 type FailureReason :: *
 data FailureReason
   | NoReason

--- a/hspec-api/api/Test.Hspec.Api.Format.V2
+++ b/hspec-api/api/Test.Hspec.Api.Format.V2
@@ -41,6 +41,7 @@ data Config = hspec-core:Test.Hspec.Core.Config.Definition.Config
   hspec-core:Test.Hspec.Core.Config.Definition.configFormatter :: Maybe hspec-core:Test.Hspec.Core.Formatters.V1.Monad.Formatter
   hspec-core:Test.Hspec.Core.Config.Definition.configHtmlOutput :: Bool
   hspec-core:Test.Hspec.Core.Config.Definition.configConcurrentJobs :: Maybe Int
+  hspec-core:Test.Hspec.Core.Config.Definition.configAnnotations :: hspec-core:Test.Hspec.Core.Annotations.Annotations
 type Event :: *
 data Event
   | Started

--- a/hspec-api/api/Test.Hspec.Api.Formatters.V2
+++ b/hspec-api/api/Test.Hspec.Api.Formatters.V2
@@ -56,6 +56,7 @@ data Config = hspec-core:Test.Hspec.Core.Config.Definition.Config
   hspec-core:Test.Hspec.Core.Config.Definition.configFormatter :: Maybe hspec-core:Test.Hspec.Core.Formatters.V1.Monad.Formatter
   hspec-core:Test.Hspec.Core.Config.Definition.configHtmlOutput :: Bool
   hspec-core:Test.Hspec.Core.Config.Definition.configConcurrentJobs :: Maybe Int
+  hspec-core:Test.Hspec.Core.Config.Definition.configAnnotations :: hspec-core:Test.Hspec.Core.Annotations.Annotations
 type FailureReason :: *
 data FailureReason
   | NoReason

--- a/hspec-api/api/Test.Hspec.Api.Formatters.V3
+++ b/hspec-api/api/Test.Hspec.Api.Formatters.V3
@@ -42,6 +42,7 @@ data Config = hspec-core:Test.Hspec.Core.Config.Definition.Config
   hspec-core:Test.Hspec.Core.Config.Definition.configFormatter :: Maybe hspec-core:Test.Hspec.Core.Formatters.V1.Monad.Formatter
   hspec-core:Test.Hspec.Core.Config.Definition.configHtmlOutput :: Bool
   hspec-core:Test.Hspec.Core.Config.Definition.configConcurrentJobs :: Maybe Int
+  hspec-core:Test.Hspec.Core.Config.Definition.configAnnotations :: hspec-core:Test.Hspec.Core.Annotations.Annotations
 type FailureReason :: *
 data FailureReason
   | NoReason

--- a/hspec-core/api/Test.Hspec.Core.Extension
+++ b/hspec-core/api/Test.Hspec.Core.Extension
@@ -1,4 +1,5 @@
-useFormatter :: (String, Formatter) -> Config -> Config
+registerOptions :: GHC.Stack.Types.HasCallStack => [Option] -> SpecWith a
+registerTransformation :: (Config -> [SpecTree] -> [SpecTree]) -> SpecWith a
 type Config :: *
 data Config = hspec-core:Test.Hspec.Core.Config.Definition.Config
   hspec-core:Test.Hspec.Core.Config.Definition.configIgnoreConfigFile :: Bool
@@ -36,69 +37,28 @@ data Config = hspec-core:Test.Hspec.Core.Config.Definition.Config
   hspec-core:Test.Hspec.Core.Config.Definition.configExpertMode :: Bool
   hspec-core:Test.Hspec.Core.Config.Definition.configAvailableFormatters :: [(String, Test.Hspec.Core.Format.FormatConfig -> IO Test.Hspec.Core.Format.Format)]
   hspec-core:Test.Hspec.Core.Config.Definition.configFormat :: Maybe (Test.Hspec.Core.Format.FormatConfig -> IO Test.Hspec.Core.Format.Format)
-  hspec-core:Test.Hspec.Core.Config.Definition.configFormatter :: Maybe Formatter
+  hspec-core:Test.Hspec.Core.Config.Definition.configFormatter :: Maybe hspec-core:Test.Hspec.Core.Formatters.V1.Monad.Formatter
   hspec-core:Test.Hspec.Core.Config.Definition.configHtmlOutput :: Bool
   hspec-core:Test.Hspec.Core.Config.Definition.configConcurrentJobs :: Maybe Int
   hspec-core:Test.Hspec.Core.Config.Definition.configAnnotations :: hspec-core:Test.Hspec.Core.Annotations.Annotations
-type FailureReason :: *
-data FailureReason
-  | NoReason
-  | Reason String
-  | ExpectedButGot (Maybe String) String String
-  | Error (Maybe String) GHC.Exception.Type.SomeException
-type FailureRecord :: *
-data FailureRecord = FailureRecord
-  failureRecordLocation :: Maybe Location
-  failureRecordPath :: Test.Hspec.Core.Util.Path
-  failureRecordMessage :: FailureReason
-type FormatM :: * -> *
-type FormatM = hspec-core:Test.Hspec.Core.Formatters.V1.Free.Free hspec-core:Test.Hspec.Core.Formatters.V1.Monad.FormatF :: * -> *
-type Formatter :: *
-data Formatter = Formatter
-  headerFormatter :: FormatM ()
-  exampleGroupStarted :: [String] -> String -> FormatM ()
-  exampleGroupDone :: FormatM ()
-  exampleStarted :: Test.Hspec.Core.Util.Path -> FormatM ()
-  exampleProgress :: Test.Hspec.Core.Util.Path -> Progress -> FormatM ()
-  exampleSucceeded :: Test.Hspec.Core.Util.Path -> String -> FormatM ()
-  exampleFailed :: Test.Hspec.Core.Util.Path -> String -> FailureReason -> FormatM ()
-  examplePending :: Test.Hspec.Core.Util.Path -> String -> Maybe String -> FormatM ()
-  failedFormatter :: FormatM ()
-  footerFormatter :: FormatM ()
-type Location :: *
-data Location = Location
-  locationFile :: FilePath
-  locationLine :: Int
-  locationColumn :: Int
-type Progress :: *
-type Progress = (Int, Int)
-type Seconds :: *
-newtype Seconds = Seconds Double
+type Item :: * -> *
+data Item a = hspec-core:Test.Hspec.Core.Tree.Item
+  hspec-core:Test.Hspec.Core.Tree.itemRequirement :: String
+  hspec-core:Test.Hspec.Core.Tree.itemLocation :: Maybe hspec-core:Test.Hspec.Core.Example.Location.Location
+  hspec-core:Test.Hspec.Core.Tree.itemIsParallelizable :: Maybe Bool
+  hspec-core:Test.Hspec.Core.Tree.itemIsFocused :: Bool
+  hspec-core:Test.Hspec.Core.Tree.itemAnnotations :: hspec-core:Test.Hspec.Core.Annotations.Annotations
+  hspec-core:Test.Hspec.Core.Tree.itemExample :: hspec-core:Test.Hspec.Core.Example.Params -> (hspec-core:Test.Hspec.Core.Example.ActionWith a -> IO ()) -> hspec-core:Test.Hspec.Core.Example.ProgressCallback -> IO hspec-core:Test.Hspec.Core.Example.Result
+type Option :: *
+newtype Option = hspec-core:Test.Hspec.Core.Extension.Config.Type.Option
+  hspec-core:Test.Hspec.Core.Extension.Config.Type.unOption :: hspec-core:GetOpt.Declarative.Types.Option Config
+type role SpecM nominal nominal
+type SpecM :: * -> * -> *
+newtype SpecM a r = hspec-core:Test.Hspec.Core.Spec.Monad.SpecM
+  hspec-core:Test.Hspec.Core.Spec.Monad.unSpecM :: Control.Monad.Trans.Writer.Lazy.WriterT (base:Data.Semigroup.Internal.Endo Config, [hspec-core:Test.Hspec.Core.Tree.SpecTree a]) (Control.Monad.Trans.Reader.ReaderT hspec-core:Test.Hspec.Core.Spec.Monad.Env IO) r
+type SpecTree :: *
+type SpecTree = hspec-core:Test.Hspec.Core.Tree.SpecTree ()
 type SpecWith :: * -> *
-type SpecWith a = hspec-core:Test.Hspec.Core.Spec.Monad.SpecM a ()
-checks :: Formatter
-extraChunk :: String -> FormatM ()
-failed_examples :: Formatter
-formatException :: GHC.Exception.Type.SomeException -> String
-formatterToFormat :: Formatter -> Test.Hspec.Core.Format.FormatConfig -> IO Test.Hspec.Core.Format.Format
-getCPUTime :: FormatM (Maybe Seconds)
-getFailCount :: FormatM Int
-getFailMessages :: FormatM [FailureRecord]
-getPendingCount :: FormatM Int
-getRealTime :: FormatM Seconds
-getSuccessCount :: FormatM Int
-getTotalCount :: FormatM Int
-missingChunk :: String -> FormatM ()
+type SpecWith a = SpecM a ()
 modifyConfig :: (Config -> Config) -> SpecWith a
-progress :: Formatter
-silent :: Formatter
-specdoc :: Formatter
-useDiff :: FormatM Bool
-usedSeed :: FormatM Integer
-withFailColor :: FormatM a -> FormatM a
-withInfoColor :: FormatM a -> FormatM a
-withPendingColor :: FormatM a -> FormatM a
-withSuccessColor :: FormatM a -> FormatM a
-write :: String -> FormatM ()
-writeLine :: String -> FormatM ()
-writeTransient :: String -> FormatM ()
+runIO :: IO r -> SpecM a r

--- a/hspec-core/api/Test.Hspec.Core.Extension.Config
+++ b/hspec-core/api/Test.Hspec.Core.Extension.Config
@@ -1,14 +1,3 @@
-evalSpec :: Config -> SpecWith a -> IO (Config, [hspec-core:Test.Hspec.Core.Tree.SpecTree a])
-evaluateResult :: SpecResult -> IO ()
-evaluateSummary :: Summary -> IO ()
-hspec :: Spec -> IO ()
-hspecResult :: Spec -> IO Summary
-hspecWith :: Config -> Spec -> IO ()
-hspecWithResult :: Config -> Spec -> IO Summary
-registerDefaultFormatter :: (String, Test.Hspec.Core.Format.FormatConfig -> IO Test.Hspec.Core.Format.Format) -> Config -> Config
-registerFormatter :: (String, Test.Hspec.Core.Format.FormatConfig -> IO Test.Hspec.Core.Format.Format) -> Config -> Config
-runSpec :: Spec -> Config -> IO Summary
-runSpecForest :: [hspec-core:Test.Hspec.Core.Tree.SpecTree ()] -> Config -> IO SpecResult
 type ColorMode :: *
 data ColorMode
   | ColorAuto
@@ -57,35 +46,10 @@ data Config = Config
   configAnnotations :: hspec-core:Test.Hspec.Core.Annotations.Annotations
 type Path :: *
 type Path = ([String], String)
-type ResultItem :: *
-data ResultItem = hspec-core:Test.Hspec.Core.Runner.Result.ResultItem
-  resultItemPath :: Path
-  resultItemStatus :: ResultItemStatus
-type ResultItemStatus :: *
-data ResultItemStatus
-  | ResultItemSuccess
-  | ResultItemPending
-  | ResultItemFailure
-type Spec :: *
-type Spec = SpecWith ()
-type SpecResult :: *
-data SpecResult = hspec-core:Test.Hspec.Core.Runner.Result.SpecResult
-  specResultItems :: [ResultItem]
-  specResultSuccess :: !Bool
-type SpecWith :: * -> *
-type SpecWith a = hspec-core:Test.Hspec.Core.Spec.Monad.SpecM a ()
-type Summary :: *
-data Summary = Summary
-  summaryExamples :: {-# UNPACK #-}Int
-  summaryFailures :: {-# UNPACK #-}Int
 type UnicodeMode :: *
 data UnicodeMode
   | UnicodeAuto
   | UnicodeNever
   | UnicodeAlways
-configAddFilter :: (Path -> Bool) -> Config -> Config
-defaultConfig :: Config
-isSuccess :: Summary -> Bool
-readConfig :: Config -> [String] -> IO Config
-resultItemIsFailure :: ResultItem -> Bool
-toSummary :: SpecResult -> Summary
+getAnnotation :: base:Data.Typeable.Internal.Typeable value => Config -> Maybe value
+setAnnotation :: base:Data.Typeable.Internal.Typeable value => value -> Config -> Config

--- a/hspec-core/api/Test.Hspec.Core.Extension.Item
+++ b/hspec-core/api/Test.Hspec.Core.Extension.Item
@@ -1,0 +1,44 @@
+getAnnotation :: base:Data.Typeable.Internal.Typeable value => Item a -> Maybe value
+isFocused :: Item a -> Bool
+pending :: Item a -> Item a
+pendingWith :: String -> Item a -> Item a
+setAnnotation :: base:Data.Typeable.Internal.Typeable value => value -> Item a -> Item a
+type ActionWith :: * -> *
+type ActionWith a = a -> IO ()
+type FailureReason :: *
+data FailureReason
+  | NoReason
+  | Reason String
+  | ColorizedReason String
+  | ExpectedButGot (Maybe String) String String
+  | Error (Maybe String) GHC.Exception.Type.SomeException
+type Item :: * -> *
+data Item a = Item
+  itemRequirement :: String
+  itemLocation :: Maybe Location
+  itemIsParallelizable :: Maybe Bool
+  itemIsFocused :: Bool
+  itemAnnotations :: hspec-core:Test.Hspec.Core.Annotations.Annotations
+  itemExample :: Params -> (ActionWith a -> IO ()) -> ProgressCallback -> IO Result
+type Location :: *
+data Location = Location
+  locationFile :: FilePath
+  locationLine :: Int
+  locationColumn :: Int
+type Params :: *
+data Params = Params
+  paramsQuickCheckArgs :: Test.QuickCheck.Test.Args
+  paramsSmallCheckDepth :: Maybe Int
+type Progress :: *
+type Progress = (Int, Int)
+type ProgressCallback :: *
+type ProgressCallback = Progress -> IO ()
+type Result :: *
+data Result = Result
+  resultInfo :: String
+  resultStatus :: ResultStatus
+type ResultStatus :: *
+data ResultStatus
+  | Success
+  | Pending (Maybe Location) (Maybe String)
+  | Failure (Maybe Location) FailureReason

--- a/hspec-core/api/Test.Hspec.Core.Extension.Spec
+++ b/hspec-core/api/Test.Hspec.Core.Extension.Spec
@@ -1,0 +1,1 @@
+mapItems :: (hspec-core:Test.Hspec.Core.Tree.Item a -> hspec-core:Test.Hspec.Core.Tree.Item b) -> hspec-core:Test.Hspec.Core.Spec.Monad.SpecWith a -> hspec-core:Test.Hspec.Core.Spec.Monad.SpecWith b

--- a/hspec-core/api/Test.Hspec.Core.Extension.Tree
+++ b/hspec-core/api/Test.Hspec.Core.Extension.Tree
@@ -1,0 +1,4 @@
+type SpecTree :: *
+type SpecTree = hspec-core:Test.Hspec.Core.Tree.SpecTree ()
+filterItems :: (hspec-core:Test.Hspec.Core.Tree.Item () -> Bool) -> [SpecTree] -> [SpecTree]
+mapItems :: (hspec-core:Test.Hspec.Core.Tree.Item () -> hspec-core:Test.Hspec.Core.Tree.Item ()) -> [SpecTree] -> [SpecTree]

--- a/hspec-core/api/Test.Hspec.Core.Spec
+++ b/hspec-core/api/Test.Hspec.Core.Spec
@@ -43,6 +43,7 @@ data Item a = Item
   itemLocation :: Maybe Location
   itemIsParallelizable :: Maybe Bool
   itemIsFocused :: Bool
+  itemAnnotations :: hspec-core:Test.Hspec.Core.Annotations.Annotations
   itemExample :: Params -> (ActionWith a -> IO ()) -> ProgressCallback -> IO Result
 type Location :: *
 data Location = Location

--- a/hspec-core/hspec-core.cabal
+++ b/hspec-core/hspec-core.cabal
@@ -41,6 +41,7 @@ library
     , array
     , base >=4.9.0.0 && <5
     , call-stack >=0.2.0
+    , containers
     , deepseq
     , directory
     , filepath
@@ -53,6 +54,12 @@ library
     , time
     , transformers >=0.2.2.0
   exposed-modules:
+      Test.Hspec.Core.Extension
+      Test.Hspec.Core.Extension.Item
+      Test.Hspec.Core.Extension.Spec
+      Test.Hspec.Core.Extension.Tree
+      Test.Hspec.Core.Extension.Option
+      Test.Hspec.Core.Extension.Config
       Test.Hspec.Core.Spec
       Test.Hspec.Core.Hooks
       Test.Hspec.Core.Runner
@@ -69,6 +76,7 @@ library
       GetOpt.Declarative.Types
       GetOpt.Declarative.Util
       NonEmpty
+      Test.Hspec.Core.Annotations
       Test.Hspec.Core.Clock
       Test.Hspec.Core.Compat
       Test.Hspec.Core.Config
@@ -76,6 +84,7 @@ library
       Test.Hspec.Core.Config.Options
       Test.Hspec.Core.Example
       Test.Hspec.Core.Example.Location
+      Test.Hspec.Core.Extension.Config.Type
       Test.Hspec.Core.FailureReport
       Test.Hspec.Core.Formatters.Diff
       Test.Hspec.Core.Formatters.Internal
@@ -125,6 +134,7 @@ test-suite spec
     , base >=4.9.0.0 && <5
     , base-orphans
     , call-stack >=0.2.0
+    , containers
     , deepseq
     , directory
     , filepath
@@ -148,6 +158,7 @@ test-suite spec
       GetOpt.Declarative.Types
       GetOpt.Declarative.Util
       NonEmpty
+      Test.Hspec.Core.Annotations
       Test.Hspec.Core.Clock
       Test.Hspec.Core.Compat
       Test.Hspec.Core.Config
@@ -155,6 +166,13 @@ test-suite spec
       Test.Hspec.Core.Config.Options
       Test.Hspec.Core.Example
       Test.Hspec.Core.Example.Location
+      Test.Hspec.Core.Extension
+      Test.Hspec.Core.Extension.Config
+      Test.Hspec.Core.Extension.Config.Type
+      Test.Hspec.Core.Extension.Item
+      Test.Hspec.Core.Extension.Option
+      Test.Hspec.Core.Extension.Spec
+      Test.Hspec.Core.Extension.Tree
       Test.Hspec.Core.FailureReport
       Test.Hspec.Core.Format
       Test.Hspec.Core.Formatters
@@ -190,6 +208,7 @@ test-suite spec
       Helper
       Mock
       SpecHook
+      Test.Hspec.Core.AnnotationsSpec
       Test.Hspec.Core.ClockSpec
       Test.Hspec.Core.CompatSpec
       Test.Hspec.Core.Config.DefinitionSpec

--- a/hspec-core/package.yaml
+++ b/hspec-core/package.yaml
@@ -18,6 +18,7 @@ ghc-options: -Wall -fno-warn-incomplete-uni-patterns
 
 dependencies:
   - base >= 4.9.0.0 && < 5
+  - containers
   - random
   - tf-random
   - ansi-terminal >= 0.6.2
@@ -49,6 +50,12 @@ when:
 
 library:
   exposed-modules:
+    - Test.Hspec.Core.Extension
+    - Test.Hspec.Core.Extension.Item
+    - Test.Hspec.Core.Extension.Spec
+    - Test.Hspec.Core.Extension.Tree
+    - Test.Hspec.Core.Extension.Option
+    - Test.Hspec.Core.Extension.Config
     - Test.Hspec.Core.Spec
     - Test.Hspec.Core.Hooks
     - Test.Hspec.Core.Runner

--- a/hspec-core/src/Test/Hspec/Core/Annotations.hs
+++ b/hspec-core/src/Test/Hspec/Core/Annotations.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Test.Hspec.Core.Annotations (
+  Annotations
+, setValue
+, getValue
+) where
+
+import           Prelude ()
+import           Test.Hspec.Core.Compat
+
+import           Data.Typeable
+import           Data.Dynamic
+import           Data.Map (Map)
+import qualified Data.Map as Map
+
+newtype Annotations = Annotations (Map TypeRep Dynamic)
+  deriving (
+#if MIN_VERSION_base(4,11,0)
+  Semigroup,
+#endif
+  Monoid)
+
+setValue :: Typeable value => value -> Annotations -> Annotations
+setValue value (Annotations values) = Annotations $ Map.insert (typeOf value) (toDyn value) values
+
+getValue :: forall value. Typeable value => Annotations -> Maybe value
+getValue (Annotations values) = Map.lookup (typeOf (undefined :: value)) values >>= fromDynamic

--- a/hspec-core/src/Test/Hspec/Core/Config/Definition.hs
+++ b/hspec-core/src/Test/Hspec/Core/Config/Definition.hs
@@ -7,6 +7,12 @@ module Test.Hspec.Core.Config.Definition (
 
 , filterOr
 
+, setConfigAnnotation
+, getConfigAnnotation
+
+, addExtensionOptions
+, getExtensionOptions
+
 , getSeed
 , getFormatter
 
@@ -15,6 +21,9 @@ module Test.Hspec.Core.Config.Definition (
 , smallCheckOptions
 , quickCheckOptions
 , runnerOptions
+
+, flag
+, option
 
 #ifdef TEST
 , splitOn
@@ -28,6 +37,9 @@ import           System.Directory (getTemporaryDirectory, removeFile)
 import           System.IO (openTempFile, hClose)
 import           System.Process (system)
 
+import           Test.Hspec.Core.Annotations (Annotations)
+import qualified Test.Hspec.Core.Annotations as Annotations
+
 import           Test.Hspec.Core.Format (Format, FormatConfig)
 import           Test.Hspec.Core.Formatters.Pretty (pretty2)
 import qualified Test.Hspec.Core.Formatters.V1.Monad as V1
@@ -35,6 +47,23 @@ import qualified Test.Hspec.Core.Formatters.V1.Internal as V1 (formatterToFormat
 import           Test.Hspec.Core.Util
 
 import           GetOpt.Declarative
+
+setConfigAnnotation :: Typeable value => value -> Config -> Config
+setConfigAnnotation value config = config { configAnnotations = Annotations.setValue value $ configAnnotations config }
+
+getConfigAnnotation :: Typeable value => Config -> Maybe value
+getConfigAnnotation = Annotations.getValue . configAnnotations
+
+newtype ExtensionOptions = ExtensionOptions { unExtensionOptions :: [(String, [Option Config])] }
+
+addExtensionOptions :: String -> [Option Config] -> Config -> Config
+addExtensionOptions section opts config = setExtensionOptions ((section, opts) : getExtensionOptions config) config
+
+setExtensionOptions :: [(String, [Option Config])] -> Config -> Config
+setExtensionOptions = setConfigAnnotation . ExtensionOptions
+
+getExtensionOptions :: Config -> [(String, [Option Config])]
+getExtensionOptions = maybe [] unExtensionOptions . getConfigAnnotation
 
 getFormatter :: Config -> Maybe (FormatConfig -> IO Format)
 getFormatter config = configFormat config <|> V1.formatterToFormat <$> configFormatter config
@@ -99,6 +128,7 @@ data Config = Config {
 , configFormatter :: Maybe V1.Formatter
 , configHtmlOutput :: Bool
 , configConcurrentJobs :: Maybe Int
+, configAnnotations :: Annotations
 }
 {-# DEPRECATED configFormatter "Use [@useFormatter@](https://hackage.haskell.org/package/hspec-api/docs/Test-Hspec-Api-Formatters-V1.html#v:useFormatter) instead." #-}
 {-# DEPRECATED configQuickCheckSeed "Use `configSeed` instead." #-}
@@ -143,6 +173,7 @@ mkDefaultConfig formatters = Config {
 , configFormatter = Nothing
 , configHtmlOutput = False
 , configConcurrentJobs = Nothing
+, configAnnotations = mempty
 }
 
 defaultDiffContext :: Int

--- a/hspec-core/src/Test/Hspec/Core/Config/Options.hs
+++ b/hspec-core/src/Test/Hspec/Core/Config/Options.hs
@@ -32,9 +32,10 @@ otherOptions config = [
   , ("FORMATTER OPTIONS", formatterOptions formatters)
   , ("OPTIONS FOR QUICKCHECK", quickCheckOptions)
   , ("OPTIONS FOR SMALLCHECK", smallCheckOptions)
-  ]
+  ] ++ extensionOptions
   where
     formatters = configAvailableFormatters config
+    extensionOptions = getExtensionOptions config
 
 ignoreConfigFile :: Config -> [String] -> IO Bool
 ignoreConfigFile config args = do

--- a/hspec-core/src/Test/Hspec/Core/Extension.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension.hs
@@ -1,0 +1,112 @@
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+-- | Stability: unstable
+module Test.Hspec.Core.Extension {-# WARNING "This API is experimental." #-} (
+-- * Lifecycle of a test run
+{- |
+A test run goes through four distinct phases:
+
+1. A tree of spec items and a default `Config` are constructed in `SpecM`.
+2. Command-line options are parsed.  This transforms the default `Config` that was constructed in phase 1.
+3. The tree of spec items is transformed in various ways, depending on specific `Config` values.
+4. Each spec item is executed and its result is reported to the user.
+
+An extension can directly influence phase 1, and indirectly influence phases 2-4.
+
+When writing extensions the following imports are recommended:
+
+@
+import "Test.Hspec.Core.Extension"
+import "Test.Hspec.Core.Extension.Config" qualified as Config
+import "Test.Hspec.Core.Extension.Option" qualified as Option
+import "Test.Hspec.Core.Extension.Item" qualified as Item
+import "Test.Hspec.Core.Extension.Spec" qualified as Spec
+import "Test.Hspec.Core.Extension.Tree" qualified as Tree
+@
+-}
+
+-- ** Phase 1: Constructing a spec tree
+{- |
+- An extension can use @Spec.`Test.Hspec.Core.Extension.Spec.mapItems`@ to transform spec items in phase 1.
+
+    * @Item.`setAnnotation`@ can be used to add custom metadata to a spec `Item`.
+
+- An extension can use `modifyConfig` to modify the default config.
+
+    * @Config.`Test.Hspec.Core.Extension.Config.setAnnotation`@ can be used to add custom metadata to the default `Config`.
+-}
+  runIO
+, modifyConfig
+
+-- ** Phase 2: Parsing command-line options
+{- |
+An extension can use `registerOptions` during phase 1 to register custom command-line options, and as a consequence indirectly influence this phase.
+
+* Options can use @Config.`Test.Hspec.Core.Extension.Config.setAnnotation`@ to add custom metadata to the `Config`.
+-}
+, Option
+, registerOptions
+
+-- ** Phase 3: Transforming the spec tree
+{- |
+An extension can use `registerTransformation` during phase 1 to indirectly influence this phase.
+-}
+, registerTransformation
+
+-- ** Phase 4: Reporting results
+{- |
+An extension can register a [custom formatter](https://hspec.github.io/extending-hspec-formatter.html) in phase 1 to indirectly influence this phase.
+-}
+
+-- * Types
+{- |
+Operations on these types are provided by the following modules respectively:
+
+* "Test.Hspec.Core.Extension.Config"
+* "Test.Hspec.Core.Extension.Item"
+* "Test.Hspec.Core.Extension.Spec"
+* "Test.Hspec.Core.Extension.Tree"
+-}
+, Config
+, Item
+, SpecM
+, SpecWith
+, SpecTree
+) where
+
+import           Prelude ()
+import           Test.Hspec.Core.Compat
+
+import qualified Data.CallStack as CallStack
+
+import qualified GetOpt.Declarative as Declarative
+import           Test.Hspec.Core.Spec (SpecM, SpecWith, runIO, modifyConfig)
+import qualified Test.Hspec.Core.Spec as Core
+import qualified Test.Hspec.Core.Config.Definition as Core
+
+import           Test.Hspec.Core.Extension.Config (Config)
+import qualified Test.Hspec.Core.Extension.Config.Type as Config
+import           Test.Hspec.Core.Extension.Option
+import           Test.Hspec.Core.Extension.Item
+import           Test.Hspec.Core.Extension.Tree
+
+registerOptions :: HasCallStack => [Option] -> SpecWith a
+registerOptions = Core.modifyConfig . Core.addExtensionOptions section . map liftOption
+  where
+    section = "OPTIONS FOR " <> package
+    package = maybe "main" (CallStack.srcLocPackage . snd) CallStack.callSite
+
+    liftOption :: Option -> Declarative.Option Core.Config
+    liftOption = Config.unOption
+
+{- |
+Register a transformation that transforms the spec tree in phase 3.
+
+The registered transformation can use:
+
+- @Tree.`mapItems`@ to modify spec items
+- @Tree.`filterItems`@ to discard spec items
+- @Config.`Test.Hspec.Core.Extension.Config.getAnnotation`@ to access custom config metadata
+- @Item.`getAnnotation`@ to access custom item metadata
+-}
+registerTransformation :: (Config -> [SpecTree] -> [SpecTree]) -> SpecWith a
+registerTransformation = modifyConfig . Config.addSpecTransformation

--- a/hspec-core/src/Test/Hspec/Core/Extension/Config.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Config.hs
@@ -1,0 +1,19 @@
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+module Test.Hspec.Core.Extension.Config {-# WARNING "This API is experimental." #-} (
+-- * Types
+  Config(..)
+, Path
+, ColorMode(..)
+, UnicodeMode(..)
+
+-- * Operations
+, setAnnotation
+, getAnnotation
+) where
+
+import           Prelude ()
+
+import           Test.Hspec.Core.Format
+import           Test.Hspec.Core.Config.Definition (ColorMode(..), UnicodeMode(..))
+
+import           Test.Hspec.Core.Extension.Config.Type

--- a/hspec-core/src/Test/Hspec/Core/Extension/Config/Type.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Config/Type.hs
@@ -1,0 +1,43 @@
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
+module Test.Hspec.Core.Extension.Config.Type (
+  Option(..)
+, Config(..)
+
+, setAnnotation
+, getAnnotation
+
+, addSpecTransformation
+, applySpecTransformation
+) where
+
+import           Prelude ()
+import           Test.Hspec.Core.Compat
+
+import qualified GetOpt.Declarative as Declarative
+
+import           Test.Hspec.Core.Config.Definition (Config(..))
+import qualified Test.Hspec.Core.Config.Definition as Core
+
+import           Test.Hspec.Core.Extension.Tree (SpecTree)
+
+newtype Option = Option { unOption :: Declarative.Option Config }
+
+setAnnotation :: Typeable value => value -> Config -> Config
+setAnnotation = Core.setConfigAnnotation
+
+getAnnotation :: Typeable value => Config -> Maybe value
+getAnnotation = Core.getConfigAnnotation
+
+newtype SpecTransformation = SpecTransformation { unSpecTransformation :: Config -> [SpecTree] -> [SpecTree] }
+
+setSpecTransformation :: (Config -> [SpecTree] -> [SpecTree]) -> Config -> Config
+setSpecTransformation = setAnnotation . SpecTransformation
+
+getSpecTransformation :: Config -> Config -> [SpecTree] -> [SpecTree]
+getSpecTransformation = maybe (\ _ -> id) unSpecTransformation . getAnnotation
+
+addSpecTransformation :: (Config -> [SpecTree] -> [SpecTree]) -> Config -> Config
+addSpecTransformation f config = setSpecTransformation (\ c -> f c . getSpecTransformation config c) config
+
+applySpecTransformation :: Core.Config -> [SpecTree] -> [SpecTree]
+applySpecTransformation config = getSpecTransformation config config

--- a/hspec-core/src/Test/Hspec/Core/Extension/Item.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Item.hs
@@ -1,0 +1,46 @@
+module Test.Hspec.Core.Extension.Item {-# WARNING "This API is experimental." #-} (
+-- * Types
+  Item(..)
+, Location(..)
+, Params(..)
+, ActionWith
+, Progress
+, ProgressCallback
+, Result(..)
+, ResultStatus(..)
+, FailureReason(..)
+
+-- * Operations
+, isFocused
+, pending
+, pendingWith
+, setAnnotation
+, getAnnotation
+) where
+
+import           Prelude ()
+import           Test.Hspec.Core.Compat
+
+import           Test.Hspec.Core.Spec hiding (pending, pendingWith)
+import           Test.Hspec.Core.Tree
+
+isFocused :: Item a -> Bool
+isFocused = itemIsFocused
+
+pending :: Item a -> Item a
+pending item = item { itemExample = \ _params _hook _progress -> result }
+  where
+    result :: IO Result
+    result = return $ Result "" (Pending Nothing Nothing)
+
+pendingWith :: String -> Item a -> Item a
+pendingWith reason item = item { itemExample = \ _params _hook _progress -> result }
+  where
+    result :: IO Result
+    result = return $ Result "" (Pending Nothing (Just reason))
+
+setAnnotation :: Typeable value => value -> Item a -> Item a
+setAnnotation = setItemAnnotation
+
+getAnnotation :: Typeable value => Item a -> Maybe value
+getAnnotation = getItemAnnotation

--- a/hspec-core/src/Test/Hspec/Core/Extension/Option.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Option.hs
@@ -1,0 +1,27 @@
+module Test.Hspec.Core.Extension.Option {-# WARNING "This API is experimental." #-} (
+  Option
+, flag
+, argument
+, noArgument
+, optionalArgument
+) where
+
+import           Prelude ()
+import           Test.Hspec.Core.Compat
+
+import qualified GetOpt.Declarative as Declarative
+import qualified Test.Hspec.Core.Config.Definition as Core
+
+import           Test.Hspec.Core.Extension.Config.Type (Option(..), Config)
+
+flag :: String -> (Bool -> Config -> Config) -> String -> Option
+flag name setter = Option . Core.flag name setter
+
+argument :: String -> String -> (String -> Config -> Maybe Config) -> String -> Option
+argument name argumentName setter = Option . Core.option name (Declarative.Arg argumentName setter)
+
+optionalArgument :: String -> String -> (Maybe String -> Config -> Maybe Config) -> String -> Option
+optionalArgument name argumentName setter = Option . Core.option name (Declarative.OptArg argumentName setter)
+
+noArgument :: String -> (Config -> Config) -> String -> Option
+noArgument name setter help = Option $ Declarative.Option name Nothing (Declarative.NoArg setter) help False

--- a/hspec-core/src/Test/Hspec/Core/Extension/Spec.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Spec.hs
@@ -1,0 +1,10 @@
+module Test.Hspec.Core.Extension.Spec {-# WARNING "This API is experimental." #-} (
+  mapItems
+) where
+
+import           Prelude ()
+
+import           Test.Hspec.Core.Spec
+
+mapItems :: (Item a -> Item b) -> SpecWith a -> SpecWith b
+mapItems = mapSpecItem_

--- a/hspec-core/src/Test/Hspec/Core/Extension/Tree.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Tree.hs
@@ -1,0 +1,19 @@
+module Test.Hspec.Core.Extension.Tree {-# WARNING "This API is experimental." #-} (
+  SpecTree
+, mapItems
+, filterItems
+) where
+
+import           Prelude ()
+import           Test.Hspec.Core.Compat
+
+import           Test.Hspec.Core.Spec hiding (SpecTree)
+import qualified Test.Hspec.Core.Spec as Core
+
+type SpecTree = Core.SpecTree ()
+
+mapItems :: (Item () -> Item ()) -> [SpecTree] -> [SpecTree]
+mapItems = map . fmap
+
+filterItems :: (Item () -> Bool) -> [SpecTree] -> [SpecTree]
+filterItems = filterForest

--- a/hspec-core/src/Test/Hspec/Core/Runner.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner.hs
@@ -118,6 +118,7 @@ import           Test.Hspec.Core.Spec hiding (pruneTree, pruneForest)
 import           Test.Hspec.Core.Tree (formatDefaultDescription)
 import           Test.Hspec.Core.Config
 import           Test.Hspec.Core.Config.Definition as Config (getSeed, getFormatter)
+import           Test.Hspec.Core.Extension.Config.Type as Extension (applySpecTransformation)
 import           Test.Hspec.Core.Format (Format, FormatConfig(..))
 import qualified Test.Hspec.Core.Formatters.V2 as V2
 import           Test.Hspec.Core.FailureReport
@@ -418,6 +419,7 @@ specToEvalForest seed config =
   >>> addDefaultDescriptions
   >>> failFocusedItems config
   >>> failPendingItems config
+  >>> Extension.applySpecTransformation config
   >>> focusSpec config
   >>> toEvalItemForest params
   >>> applyDryRun config
@@ -450,7 +452,7 @@ toEvalItemForest :: Params -> [SpecTree ()] -> [EvalItemTree]
 toEvalItemForest params = bimapForest id toEvalItem . filterForest itemIsFocused
   where
     toEvalItem :: Item () -> EvalItem
-    toEvalItem (Item requirement loc isParallelizable _isFocused e) = EvalItem {
+    toEvalItem (Item requirement loc isParallelizable _isFocused _annotations e) = EvalItem {
       evalItemDescription = requirement
     , evalItemLocation = loc
     , evalItemConcurrency = if isParallelizable == Just True then Concurrent else Sequential

--- a/hspec-core/test/Test/Hspec/Core/AnnotationsSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/AnnotationsSpec.hs
@@ -1,0 +1,29 @@
+module Test.Hspec.Core.AnnotationsSpec (spec) where
+
+import           Prelude ()
+import           Helper
+
+import           Test.Hspec.Core.Annotations
+
+newtype A = A Int
+  deriving (Eq, Show)
+
+newtype B = B Int
+  deriving (Eq, Show)
+
+spec :: Spec
+spec = do
+  describe "Annotations" $ do
+    it "can store a value" $ do
+      let annotations = setValue (A 23) mempty
+      getValue annotations `shouldBe` Just (A 23)
+
+    it "can store multiple values of different types" $ do
+      let annotations = setValue (B 42) $ setValue (A 23) mempty
+      getValue annotations `shouldBe` Just (A 23)
+      getValue annotations `shouldBe` Just (B 42)
+
+    context "when a value of the same type is added multiple times" $ do
+      it "gives precedence to the value that was added last" $ do
+        let annotations = setValue (A 42) $  setValue (A 23) mempty
+        getValue annotations `shouldBe` Just (A 42)

--- a/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -27,6 +28,7 @@ import qualified Test.QuickCheck as QC
 import qualified Test.Hspec.Core.Hooks as H
 
 import           Test.Hspec.Core.Formatters.Pretty.ParserSpec (Person(..))
+import           Test.Hspec.Core.Extension ()
 
 runPropFoo :: [String] -> IO String
 runPropFoo args = unlines . normalizeSummary . lines <$> do

--- a/hspec-meta/hspec-meta.cabal
+++ b/hspec-meta/hspec-meta.cabal
@@ -44,6 +44,7 @@ library
       GetOpt.Declarative.Types
       GetOpt.Declarative.Util
       NonEmpty
+      Test.Hspec.Core.Annotations
       Test.Hspec.Core.Clock
       Test.Hspec.Core.Compat
       Test.Hspec.Core.Config
@@ -51,6 +52,13 @@ library
       Test.Hspec.Core.Config.Options
       Test.Hspec.Core.Example
       Test.Hspec.Core.Example.Location
+      Test.Hspec.Core.Extension
+      Test.Hspec.Core.Extension.Config
+      Test.Hspec.Core.Extension.Config.Type
+      Test.Hspec.Core.Extension.Item
+      Test.Hspec.Core.Extension.Option
+      Test.Hspec.Core.Extension.Spec
+      Test.Hspec.Core.Extension.Tree
       Test.Hspec.Core.FailureReport
       Test.Hspec.Core.Format
       Test.Hspec.Core.Formatters
@@ -93,6 +101,7 @@ library
     , array
     , base >=4.9.0.0 && <5
     , call-stack >=0.2.0
+    , containers
     , deepseq
     , directory
     , filepath
@@ -132,6 +141,7 @@ executable hspec-meta-discover
     , array
     , base >=4.9.0.0 && <5
     , call-stack >=0.2.0
+    , containers
     , deepseq
     , directory
     , filepath


### PR DESCRIPTION
- [x] Allow for extensions that transform the spec tree
- [ ] Allow custom command-line options for `Example` instances