### PR TITLE
Support multiple --formats at once

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Config/Definition.hs
+++ b/hspec-core/src/Test/Hspec/Core/Config/Definition.hs
@@ -29,6 +29,7 @@ import           System.Process (system)
 import           Test.Hspec.Core.Format (Format, FormatConfig)
 import           Test.Hspec.Core.Formatters.Pretty (pretty2)
 import qualified Test.Hspec.Core.Formatters.V1.Monad as V1
+import qualified Test.Hspec.Core.Formatters.V2 as V2
 import           Test.Hspec.Core.Util
 
 import           GetOpt.Declarative
@@ -178,6 +179,7 @@ argument name parser setter = Arg name $ \ input c -> flip setter c <$> parser i
 formatterOptions :: [(String, FormatConfig -> IO Format)] -> [Option Config]
 formatterOptions formatters = [
     mkOption "format" (Just 'f') (argument "NAME" readFormatter addFormatter) helpForFormat
+  , mkOption "add-format" Nothing (argument "NAME" readFormatter $ \f -> addFormatter f . defFormatter) helpForFormat
   , flag "color" setColor "colorize the output"
   , flag "unicode" setUnicode "output unicode"
   , flag "diff" setDiff "show colorized diffs"
@@ -214,6 +216,11 @@ formatterOptions formatters = [
 
     readFormatter :: String -> Maybe (FormatConfig -> IO Format)
     readFormatter = (`lookup` formatters)
+
+    defFormatter :: Config -> Config
+    defFormatter config = config
+      { configFormat = configFormat config <|> Just (V2.formatterToFormat V2.checks)
+      }
 
     addFormatter :: (FormatConfig -> IO Format) -> Config -> Config
     addFormatter f config = config


### PR DESCRIPTION
### [Support passing --format more than once](https://github.com/hspec/hspec/pull/895/commits/5ee26a5f9d07c3b74fb9334fafdf4a004392e280)
[5ee26a5](https://github.com/hspec/hspec/pull/895/commits/5ee26a5f9d07c3b74fb9334fafdf4a004392e280)

We use a JUnit formatter that produces an XML file for external
analysis. When we do this, we'd like to still output the normal format
in the build logs, since viewing them there is also useful. Many of our
Engineers get confused when their build fails tests and they navigate to
the GitHub action and see no output. The summary and annotations
produced from our JUnit report are both less intuitive to find (although
more useful once they are found, which is why we do it).

This commit changes the behavior when passing `--format` multiple times
from "last wins" to "use them all". That way, we can pass `--format
checks --format junit` to achieve what we want.

### [Add --add-format option](https://github.com/hspec/hspec/pull/895/commits/57555adffa40c7f07d520d051c60da38f4b44ad1)
[57555ad](https://github.com/hspec/hspec/pull/895/commits/57555adffa40c7f07d520d051c60da38f4b44ad1)

This option can be used when you want to use a formatter in addition to
the default. Without this option, one would have to use `--format checks
--format junit` to get that behavior, which duplicates knowledge of the
default formatter and can easily be missed. Now, they can use
`--add-format junit` to accomplish it more directly.

The flag and help are placeholder; I'm happy to name it and document it
however you like.