### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig configuration
+# http://editorconfig.org
+
+# Don't look above this file for other ones.
+root = true
+
+# Unix-style newlines with a newline ending every file, utf-8 charset
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# Match Haskell files, set indent to spaces with width of two
+[*.hs]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This is useful so that editors will just have the right settings for Haskell without having to guess.