### PR TITLE
hspec-core: use warning category for experimental

### DIFF
--- a/changes/deprecations-category
+++ b/changes/deprecations-category
@@ -1,0 +1,1 @@
+  - Experimental modules are now marked as `-Wx-experimental` instead of `-Wdeprecations`; suppressions need to be updated to `-Wno-x-experimental` rather than `-Wno-deprecations`.

--- a/hspec-core/src/Test/Hspec/Core/Extension.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension.hs
@@ -1,6 +1,6 @@
-{-# OPTIONS_GHC -fno-warn-deprecations #-}
+{-# OPTIONS_GHC -Wno-x-experimental #-}
 -- | Stability: unstable
-module Test.Hspec.Core.Extension {-# WARNING "This API is experimental." #-} (
+module Test.Hspec.Core.Extension {-# WARNING in "x-experimental" "This API is experimental." #-} (
 -- * Lifecycle of a test run
 {- |
 A test run goes through four distinct phases:

--- a/hspec-core/src/Test/Hspec/Core/Extension/Config.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Config.hs
@@ -1,5 +1,4 @@
-{-# OPTIONS_GHC -fno-warn-deprecations #-}
-module Test.Hspec.Core.Extension.Config {-# WARNING "This API is experimental." #-} (
+module Test.Hspec.Core.Extension.Config {-# WARNING in "x-experimental" "This API is experimental." #-} (
 -- * Types
   Config(..)
 , Path

--- a/hspec-core/src/Test/Hspec/Core/Extension/Config/Type.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Config/Type.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -fno-warn-deprecations #-}
+{-# OPTIONS_GHC -Wno-x-experimental #-}
 module Test.Hspec.Core.Extension.Config.Type (
   Option(..)
 , Config(..)

--- a/hspec-core/src/Test/Hspec/Core/Extension/Item.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Item.hs
@@ -1,4 +1,4 @@
-module Test.Hspec.Core.Extension.Item {-# WARNING "This API is experimental." #-} (
+module Test.Hspec.Core.Extension.Item {-# WARNING in "x-experimental" "This API is experimental." #-} (
 -- * Types
   Item(..)
 , Location(..)

--- a/hspec-core/src/Test/Hspec/Core/Extension/Option.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Option.hs
@@ -1,4 +1,4 @@
-module Test.Hspec.Core.Extension.Option {-# WARNING "This API is experimental." #-} (
+module Test.Hspec.Core.Extension.Option {-# WARNING in "x-experimental" "This API is experimental." #-} (
   Option
 , flag
 , argument

--- a/hspec-core/src/Test/Hspec/Core/Extension/Tree.hs
+++ b/hspec-core/src/Test/Hspec/Core/Extension/Tree.hs
@@ -1,4 +1,4 @@
-module Test.Hspec.Core.Extension.Tree {-# WARNING "This API is experimental." #-} (
+module Test.Hspec.Core.Extension.Tree {-# WARNING in "x-experimental" "This API is experimental." #-} (
   SpecTree
 , mapItems
 , filterItems

--- a/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
+++ b/hspec-core/test/Test/Hspec/Core/RunnerSpec.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -fno-warn-deprecations #-}
+{-# OPTIONS_GHC -Wno-x-experimental #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}


### PR DESCRIPTION
This allows suppressing the warning much more finely than "just ignore all deprecation warnings".

Note that this would mean a minimum GHC version of 9.8 (AFAICT based on when it appeared in docs, have not tested that old).

See: https://downloads.haskell.org/ghc/9.8.2/docs/users_guide/exts/pragmas.html?highlight=warning%20pragma