### PR TITLE
Add given prefix to discovered modules

### DIFF
--- a/hspec-discover/src/Test/Hspec/Discover/Run.hs
+++ b/hspec-discover/src/Test/Hspec/Discover/Run.hs
@@ -63,14 +63,17 @@ mkSpecModule src conf nodes =
   . showString "{-# LANGUAGE NoImplicitPrelude #-}\n"
   . showString "{-# OPTIONS_GHC -w -Wall -fno-warn-warnings-deprecations #-}\n"
   . showString ("module " ++ moduleName src conf ++ " where\n")
-  . importList nodes
+  . importList prefix nodes
   . showString "import Test.Hspec.Discover\n"
   . maybe driver driverWithFormatter (configFormatter conf)
   . showString "spec :: Spec\n"
   . showString "spec = "
-  . formatSpecs nodes
+  . formatSpecs prefix nodes
   ) "\n"
   where
+    prefix = case configModuleName conf of
+      Just name | '.' `elem` name -> moduleNameFromId name
+      _ -> ""
     driver =
         case configNoMain conf of
           False ->
@@ -99,11 +102,11 @@ moduleNameFromId :: String -> String
 moduleNameFromId = reverse . dropWhile (== '.') . dropWhile (/= '.') . reverse
 
 -- | Generate imports for a list of specs.
-importList :: Maybe [Spec] -> ShowS
-importList = foldr (.) "" . map f . maybe [] moduleNames
+importList :: String -> Maybe [Spec] -> ShowS
+importList prefix = foldr (.) "" . map f . maybe [] moduleNames
   where
     f :: String -> ShowS
-    f spec = "import qualified " . showString spec . "\n"
+    f spec = "import qualified " . showString (addPrefix prefix spec) . "\n"
 
 moduleNames :: [Spec] -> [String]
 moduleNames = fromForest
@@ -120,16 +123,20 @@ moduleNames = fromForest
 sequenceS :: [ShowS] -> ShowS
 sequenceS = foldr (.) "" . intersperse " >> "
 
-formatSpecs :: Maybe [Spec] -> ShowS
-formatSpecs = maybe "return ()" fromForest
+formatSpecs :: String -> Maybe [Spec] -> ShowS
+formatSpecs prefix = maybe "return ()" fromForest
   where
     fromForest :: [Spec] -> ShowS
     fromForest = sequenceS . map fromTree
 
     fromTree :: Spec -> ShowS
     fromTree tree = case tree of
-      Spec name -> "describe " . shows name . " " . showString name . "Spec.spec"
-      Hook name forest -> "(" . showString name . ".hook $ " . fromForest forest . ")"
+      Spec name -> "describe " . shows (addPrefix prefix name) . " " . showString (addPrefix prefix name) . "Spec.spec"
+      Hook name forest -> "(" . showString (addPrefix prefix name) . ".hook $ " . fromForest forest . ")"
+
+addPrefix :: String -> String -> String
+addPrefix "" name = name
+addPrefix prefix name = prefix ++ "." ++ name
 
 findSpecs :: FilePath -> IO (Maybe [Spec])
 findSpecs = fmap (fmap toSpecs) . discover

--- a/hspec-discover/test/Test/Hspec/Discover/RunSpec.hs
+++ b/hspec-discover/test/Test/Hspec/Discover/RunSpec.hs
@@ -83,6 +83,48 @@ spec = do
           ]
         ]
 
+    it "prefixes discovered modules when --module-name is qualified" $ do
+      touch "test/Generate/GenerateSpec.hs"
+      touch "test/Generate/Foo/BarSpec.hs"
+      run ["test/Generate/Spec.hs", "", "out", "--module-name=Generate.Spec"]
+      readFile "out" `shouldReturn` unlines [
+          "{-# LINE 1 \"test/Generate/Spec.hs\" #-}"
+        , "{-# LANGUAGE NoImplicitPrelude #-}"
+        , "{-# OPTIONS_GHC -w -Wall -fno-warn-warnings-deprecations #-}"
+        , "module Generate.Spec where"
+        , "import qualified Generate.Foo.BarSpec"
+        , "import qualified Generate.GenerateSpec"
+        , "import Test.Hspec.Discover"
+        , "main :: IO ()"
+        , "main = hspec spec"
+        , "spec :: Spec"
+        , "spec = " ++ unwords [
+               "describe \"Generate.Foo.Bar\" Generate.Foo.BarSpec.spec"
+          , ">> describe \"Generate.Generate\" Generate.GenerateSpec.spec"
+          ]
+        ]
+
+    it "prefixes discovered modules when --module-name has multiple qualifiers" $ do
+      touch "test/Foo/Bar/BazSpec.hs"
+      touch "test/Foo/Bar/Qux/QuuxSpec.hs"
+      run ["test/Foo/Bar/Spec.hs", "", "out", "--module-name=Foo.Bar.Spec"]
+      readFile "out" `shouldReturn` unlines [
+          "{-# LINE 1 \"test/Foo/Bar/Spec.hs\" #-}"
+        , "{-# LANGUAGE NoImplicitPrelude #-}"
+        , "{-# OPTIONS_GHC -w -Wall -fno-warn-warnings-deprecations #-}"
+        , "module Foo.Bar.Spec where"
+        , "import qualified Foo.Bar.BazSpec"
+        , "import qualified Foo.Bar.Qux.QuuxSpec"
+        , "import Test.Hspec.Discover"
+        , "main :: IO ()"
+        , "main = hspec spec"
+        , "spec :: Spec"
+        , "spec = " ++ unwords [
+               "describe \"Foo.Bar.Baz\" Foo.Bar.BazSpec.spec"
+          , ">> describe \"Foo.Bar.Qux.Quux\" Foo.Bar.Qux.QuuxSpec.spec"
+          ]
+        ]
+
     it "generates a test driver for an empty directory" $ do
       touch "test/Foo/Bar/Baz/.placeholder"
       run ["test/Spec.hs", "", "out"]
@@ -116,9 +158,15 @@ spec = do
 
   describe "importList" $ do
     it "generates imports for a list of specs" $ do
-      importList (Just [Run.Spec "Foo", Run.Spec "Bar"]) "" `shouldBe` unlines [
+      importList "" (Just [Run.Spec "Foo", Run.Spec "Bar"]) "" `shouldBe` unlines [
           "import qualified FooSpec"
         , "import qualified BarSpec"
+        ]
+
+    it "generates imports with module prefix" $ do
+      importList "Generate" (Just [Run.Spec "Foo", Run.Spec "Bar"]) "" `shouldBe` unlines [
+          "import qualified Generate.FooSpec"
+        , "import qualified Generate.BarSpec"
         ]
 
   describe "discover" $ do


### PR DESCRIPTION
This PR detects a module prefix in `--module-name=` and applies it to discovered specs.

Use case: `hspec-discover-discover` finds `Spec.hs` modules in all immediate subdirectories. This breaks up the size of `Spec.hs`. But if you have `test/Foo/Spec.hs`, then `hspec-discover --module-name=Foo.Spec` will correctly find all files in this subdirectory, *but* will omit the `Foo.` part of the module name!

With this PR, this won't happen. The hspec-discover call in `test/Foo/Spec.hs` will correctly find and import `test/Foo/FooSpec.hs` as `Foo.FooSpec`.

Fixes #952 

Alternative to #953 