### PR TITLE
hspec-discover: Use do-notation instead of `>>`

### DIFF
--- a/hspec-core/src/Test/Hspec/Core/Spec.hs
+++ b/hspec-core/src/Test/Hspec/Core/Spec.hs
@@ -106,6 +106,7 @@ describe :: HasCallStack => String -> SpecWith a -> SpecWith a
 describe label = withEnv pushLabel . mapSpecForest (return . specGroup label)
   where
     pushLabel (Env labels) = Env $ label : labels
+{-# OPAQUE describe #-}
 
 -- | @context@ is an alias for `describe`.
 context :: HasCallStack => String -> SpecWith a -> SpecWith a

--- a/hspec-discover/src/Test/Hspec/Discover/Run.hs
+++ b/hspec-discover/src/Test/Hspec/Discover/Run.hs
@@ -116,20 +116,22 @@ moduleNames = fromForest
       Spec name -> [name ++ "Spec"]
       Hook name forest -> name : fromForest forest
 
--- | Combine a list of strings with (>>).
-sequenceS :: [ShowS] -> ShowS
-sequenceS = foldr (.) "" . intersperse " >> "
+doBlock :: Int -> [ShowS] -> ShowS
+doBlock nesting = ("do" .) . foldr (\ statement -> (indentation .) . (statement .)) ""
+  where
+    indentation :: ShowS
+    indentation = showString $ '\n' : replicate (nesting * 2) ' '
 
 formatSpecs :: Maybe [Spec] -> ShowS
-formatSpecs = maybe "return ()" fromForest
+formatSpecs = maybe "return ()" (fromForest 1)
   where
-    fromForest :: [Spec] -> ShowS
-    fromForest = sequenceS . map fromTree
-
-    fromTree :: Spec -> ShowS
-    fromTree tree = case tree of
-      Spec name -> "describe " . shows name . " " . showString name . "Spec.spec"
-      Hook name forest -> "(" . showString name . ".hook $ " . fromForest forest . ")"
+    fromForest :: Int -> [Spec] -> ShowS
+    fromForest nesting = doBlock nesting . map fromTree
+      where
+        fromTree :: Spec -> ShowS
+        fromTree tree = case tree of
+          Spec name -> "describe " . shows name . " " . showString name . "Spec.spec"
+          Hook name forest -> showString name . ".hook $ " . fromForest (succ nesting) forest
 
 findSpecs :: FilePath -> IO (Maybe [Spec])
 findSpecs = fmap (fmap toSpecs) . discover

--- a/hspec-discover/test/Test/Hspec/Discover/RunSpec.hs
+++ b/hspec-discover/test/Test/Hspec/Discover/RunSpec.hs
@@ -26,11 +26,10 @@ spec = do
         , "main :: IO ()"
         , "main = hspec spec"
         , "spec :: Spec"
-        , "spec = " ++ unwords [
-               "describe \"Foo\" FooSpec.spec"
-          , ">> describe \"Foo.Bar\" Foo.BarSpec.spec"
-          , ">> describe \"Foo.Bar.Baz\" Foo.Bar.BazSpec.spec"
-          ]
+        , "spec = do"
+        , "  describe \"Foo\" FooSpec.spec"
+        , "  describe \"Foo.Bar\" Foo.BarSpec.spec"
+        , "  describe \"Foo.Bar.Baz\" Foo.Bar.BazSpec.spec"
         ]
 
     it "generates a test driver with no Main/main" $ do
@@ -48,11 +47,10 @@ spec = do
         , "import qualified Foo.Bar.BazSpec"
         , "import Test.Hspec.Discover"
         , "spec :: Spec"
-        , "spec = " ++ unwords [
-               "describe \"Foo\" FooSpec.spec"
-          , ">> describe \"Foo.Bar\" Foo.BarSpec.spec"
-          , ">> describe \"Foo.Bar.Baz\" Foo.Bar.BazSpec.spec"
-          ]
+        , "spec = do"
+        , "  describe \"Foo\" FooSpec.spec"
+        , "  describe \"Foo.Bar\" Foo.BarSpec.spec"
+        , "  describe \"Foo.Bar.Baz\" Foo.Bar.BazSpec.spec"
         ]
 
     it "generates a test driver with hooks" $ do
@@ -76,11 +74,12 @@ spec = do
         , "main :: IO ()"
         , "main = hspec spec"
         , "spec :: Spec"
-        , "spec = " ++ unwords [
-               "(SpecHook.hook $ describe \"Foo\" FooSpec.spec"
-          , ">> (Foo.SpecHook.hook $ describe \"Foo.Bar\" Foo.BarSpec.spec"
-          , ">> describe \"Foo.Bar.Baz\" Foo.Bar.BazSpec.spec))"
-          ]
+        , "spec = do"
+        , "  SpecHook.hook $ do"
+        , "    describe \"Foo\" FooSpec.spec"
+        , "    Foo.SpecHook.hook $ do"
+        , "      describe \"Foo.Bar\" Foo.BarSpec.spec"
+        , "      describe \"Foo.Bar.Baz\" Foo.Bar.BazSpec.spec"
         ]
 
     it "generates a test driver for an empty directory" $ do


### PR DESCRIPTION
This reduces compile times with GHC, but sadly with diminishing returns as the number of spec files increases.

```
125 spec files:

  before: 3.4s
  after:  2.5s

250 spec files:

  before: 9.6s
  after:  5.8s

500 spec files:

  before: 37.1s
  after:  24.6s

1000 spec files:

  before: 163.7s
  after:  147.8s
```

Still, as this is a strict improvement and makes the generated test driver easier to read, I think this is a good change.

In addition, from other things I tried, I suspect that this may positively impact `-O0`.