### PR TITLE
Self-deregister completed jobs from the JobQueue cancel list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,15 @@ jobs:
           test/regression/issue-270/run.sh
         if: "!startsWith(matrix.ghc, '7.') && runner.os != 'Windows'"
 
+      - name: Run issue-961 regression test
+        # Slope-based detection (see test/regression/issue-961/run.sh)
+        # is robust across GHC versions. GHC.Stats lives in base-4.10+
+        # (GHC 8.2+); on older GHCs the test self-skips.
+        run: |
+          cabal install --lib base hspec --package-env test/regression/issue-961/
+          test/regression/issue-961/run.sh
+        if: "!startsWith(matrix.ghc, '7.') && runner.os != 'Windows'"
+
   success:
     needs: build
     runs-on: ubuntu-latest

--- a/hspec-core/src/Test/Hspec/Core/Runner/JobQueue.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner/JobQueue.hs
@@ -15,7 +15,9 @@ import           Prelude ()
 import           Test.Hspec.Core.Compat
 
 import           Control.Concurrent
-import           Control.Concurrent.Async (Async, async, waitCatch, cancelMany)
+import           Control.Concurrent.Async (Async, async, asyncThreadId, cancel, waitCatch, cancelMany)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 
 import           Control.Monad.IO.Class
 
@@ -33,16 +35,16 @@ data Semaphore = Semaphore {
 , _signal :: IO ()
 }
 
-type CancelQueue = IORef [Async ()]
+type CancelQueue = IORef (Map ThreadId (Async ()))
 
 withJobQueue :: Int -> (JobQueue -> IO a) -> IO a
 withJobQueue concurrency = bracket new cancelAll
   where
     new :: IO JobQueue
-    new = JobQueue <$> newSemaphore concurrency <*> newIORef []
+    new = JobQueue <$> newSemaphore concurrency <*> newIORef Map.empty
 
     cancelAll :: JobQueue -> IO ()
-    cancelAll (JobQueue _ cancelQueue) = readIORef cancelQueue >>= cancelMany
+    cancelAll (JobQueue _ cancelQueue) = readIORef cancelQueue >>= cancelMany . Map.elems
 
 newSemaphore :: Int -> IO Semaphore
 newSemaphore capacity = do
@@ -72,10 +74,20 @@ data Partial progress a = Partial progress | Done
 runConcurrently :: forall m progress a. MonadIO m => Semaphore -> CancelQueue -> Job IO progress a -> IO (Job m progress (Either SomeException a))
 runConcurrently (Semaphore wait signal) cancelQueue action = do
   result :: MVar (Partial progress a) <- newEmptyMVar
+  ready :: MVar () <- newEmptyMVar
   let
+    awaitWorkerStart :: IO ()
+    awaitWorkerStart = readMVar ready
+
+    signalWorkerStart :: IO ()
+    signalWorkerStart = putMVar ready ()
+
     worker :: IO a
-    worker = bracket_ wait signal $ do
-      interruptible (action partialResult) `finally` done
+    worker = (do
+        awaitWorkerStart
+        bracket_ wait signal $
+          interruptible (action partialResult) `finally` done
+      ) `finally` deregisterSelf
       where
         partialResult :: progress -> IO ()
         partialResult = replaceMVar result . Partial
@@ -83,10 +95,27 @@ runConcurrently (Semaphore wait signal) cancelQueue action = do
         done :: IO ()
         done = replaceMVar result Done
 
-    pushOnCancelQueue :: Async a -> IO ()
-    pushOnCancelQueue = (modifyIORef cancelQueue . (:) . void)
+        deregisterSelf :: IO ()
+        deregisterSelf = myThreadId >>= deregister
 
-  job <- bracket (async worker) pushOnCancelQueue return
+    modifyPending :: (Map ThreadId (Async ()) -> Map ThreadId (Async ())) -> IO ()
+    modifyPending f =
+      atomicModifyIORef' cancelQueue $ \ pending -> (f pending, ())
+
+    register :: Async () -> IO ThreadId
+    register workerAsync = do
+      let tid = asyncThreadId workerAsync
+      modifyPending (Map.insert tid workerAsync)
+      return tid
+
+    deregister :: ThreadId -> IO ()
+    deregister tid = modifyPending (Map.delete tid)
+
+  job <- mask_ $
+    bracketOnError (async worker) cancel $ \ workerAsync ->
+      bracketOnError (register (void workerAsync)) deregister $ \ _tid -> do
+        signalWorkerStart
+        return workerAsync
 
   let
     waitForResult :: (progress -> m ()) -> m (Either SomeException a)

--- a/hspec-core/src/Test/Hspec/Core/Runner/JobQueue.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner/JobQueue.hs
@@ -15,7 +15,7 @@ import           Prelude ()
 import           Test.Hspec.Core.Compat
 
 import           Control.Concurrent
-import           Control.Concurrent.Async (Async, async, asyncThreadId, cancel, waitCatch, cancelMany)
+import           Control.Concurrent.Async (Async, async, asyncThreadId, cancel, cancelMany)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 
@@ -69,7 +69,7 @@ runSequentially cancelQueue action = do
   job <- runConcurrently (Semaphore wait pass) cancelQueue action
   return $ \ notifyPartial -> signal >> job notifyPartial
 
-data Partial progress a = Partial progress | Done
+data Partial progress a = Partial progress | Done (Either SomeException a)
 
 runConcurrently :: forall m progress a. MonadIO m => Semaphore -> CancelQueue -> Job IO progress a -> IO (Job m progress (Either SomeException a))
 runConcurrently (Semaphore wait signal) cancelQueue action = do
@@ -82,18 +82,15 @@ runConcurrently (Semaphore wait signal) cancelQueue action = do
     signalWorkerStart :: IO ()
     signalWorkerStart = putMVar ready ()
 
-    worker :: IO a
+    worker :: IO ()
     worker = (do
         awaitWorkerStart
-        bracket_ wait signal $
-          interruptible (action partialResult) `finally` done
+        r <- try (bracket_ wait signal (interruptible (action partialResult)))
+        replaceMVar result (Done r)
       ) `finally` deregisterSelf
       where
         partialResult :: progress -> IO ()
         partialResult = replaceMVar result . Partial
-
-        done :: IO ()
-        done = replaceMVar result Done
 
         deregisterSelf :: IO ()
         deregisterSelf = myThreadId >>= deregister
@@ -111,11 +108,10 @@ runConcurrently (Semaphore wait signal) cancelQueue action = do
     deregister :: ThreadId -> IO ()
     deregister tid = modifyPending (Map.delete tid)
 
-  job <- mask_ $
+  mask_ $
     bracketOnError (async worker) cancel $ \ workerAsync ->
-      bracketOnError (register (void workerAsync)) deregister $ \ _tid -> do
+      bracketOnError (register workerAsync) deregister $ \ _tid ->
         signalWorkerStart
-        return workerAsync
 
   let
     waitForResult :: (progress -> m ()) -> m (Either SomeException a)
@@ -123,7 +119,7 @@ runConcurrently (Semaphore wait signal) cancelQueue action = do
       r <- liftIO (takeMVar result)
       case r of
         Partial progress -> notifyPartial progress >> waitForResult notifyPartial
-        Done -> liftIO $ waitCatch job
+        Done finalResult -> return finalResult
 
   return waitForResult
 

--- a/test/regression/issue-961/Spec.hs
+++ b/test/regression/issue-961/Spec.hs
@@ -1,0 +1,91 @@
+-- Regression test for hspec#961:
+--   JobQueue.cancelQueue retained one Async (and its underlying TSO) per spec
+--   item for the lifetime of the run, growing O(n) in the number of test
+--   cases. After the fix, completed workers self-deregister, so the queue
+--   only holds in-flight jobs.
+--
+-- Detection strategy: run the synthetic suite at two sizes (small and
+-- large), measure post-GC live heap in each run, and assert that the
+-- per-test slope (bytes-per-spec-item, computed across the two sizes) is
+-- small. A leaking queue grows live heap linearly in the spec count, so
+-- the slope is the clean O(n)-vs-O(1) signal we want. A single-point
+-- measurement turns out to be unreliable: it conflates the leak with the
+-- fixed-cost overhead of the test harness itself (result tree, hspec
+-- internal state, base runtime), and the threshold for "broken" depends
+-- on GHC version / runner. Slope cancels that base out.
+--
+-- The suite is built with nested describes (outer/middle/leaf) to roughly
+-- mimic the shape of a real test tree. The leaf count scales with the
+-- chosen size N so the spec count = `outer * middle * leaf` = N exactly.
+-- N is taken from the ISSUE961_N environment variable, with a default
+-- that matches the original 50k-test reproducer.
+--
+-- An `afterAll_` hook fires after every spec item has finished while
+-- `withJobQueue`'s bracket is still open — that is the window where a
+-- leaked queue is observable. The hook forces a major GC, reads
+-- `gcdetails_live_bytes` from `GHC.Stats.getRTSStats`, and writes the
+-- number to `live-bytes.txt` for run.sh to consume. `+RTS -hT` heap
+-- profile output is preserved for diagnostic visibility but is not the
+-- decision basis.
+
+{-# LANGUAGE CPP #-}
+module Main (main) where
+
+import           Control.Concurrent (threadDelay)
+import           Control.Monad (forM_)
+import           Data.Maybe (fromMaybe)
+import           System.Environment (lookupEnv)
+import           System.Mem (performGC)
+import           Test.Hspec
+import           Text.Read (readMaybe)
+#if MIN_VERSION_base(4,10,0)
+import           GHC.Stats (getRTSStats, getRTSStatsEnabled, gc, gcdetails_live_bytes)
+#endif
+
+-- Fixed describe-tree depth: 50 outer groups, 20 middle subgroups. Leaf
+-- count is derived so that outer * middle * leaf = ISSUE961_N, which
+-- lets run.sh vary N to measure per-spec-item growth.
+outer, middle :: Int
+outer  = 50
+middle = 20
+
+defaultN :: Int
+defaultN = 50000
+
+main :: IO ()
+main = do
+  n <- fromMaybe defaultN . (>>= readMaybe) <$> lookupEnv "ISSUE961_N"
+  let leaf = max 1 (n `div` (outer * middle))
+  hspec $ afterAll_ settle $ describe "issue-961" $
+    forM_ [1 .. outer] $ \ i ->
+      describe ("group-" ++ show i) $
+        forM_ [1 .. middle] $ \ j ->
+          describe ("subgroup-" ++ show j) $
+            forM_ [1 .. leaf] $ \ k ->
+              it ("test-" ++ show i ++ "-" ++ show j ++ "-" ++ show k) $ do
+                -- Synthetic CPU work so workers spend non-trivial time in
+                -- the action body (and therefore actually concurrently
+                -- occupy the cancel queue). The shouldBe is tautological;
+                -- the leak we measure is per-item, not per-failure.
+                let xs = map (\ x -> x * x + i + j + k) [1 .. 200 :: Int]
+                sum xs `shouldBe` sum xs
+
+-- Runs after every spec item has finished, while withJobQueue's bracket is
+-- still open. We force a major GC and then read post-GC live bytes from
+-- GHC.Stats. The pause keeps the bracket open long enough for -hT to emit
+-- a few diagnostic samples in this state.
+settle :: IO ()
+settle = do
+  performGC
+  performGC
+#if MIN_VERSION_base(4,10,0)
+  enabled <- getRTSStatsEnabled
+  if enabled
+    then do
+      stats <- getRTSStats
+      writeFile "live-bytes.txt" (show (gcdetails_live_bytes (gc stats)))
+    else writeFile "live-bytes.txt" "DISABLED"
+#else
+  writeFile "live-bytes.txt" "UNAVAILABLE"
+#endif
+  threadDelay 1000000

--- a/test/regression/issue-961/run.sh
+++ b/test/regression/issue-961/run.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+#
+# Regression test for hspec#961.
+#
+# Runs the synthetic suite at two spec-count sizes (small ~ N_SMALL and
+# large ~ N_LARGE), measures post-GC live heap in each run, and asserts
+# that bytes-per-spec-item — the slope between the two — is small. A
+# leaking cancel queue retains O(n) per-worker state, so the slope is
+# the clean signal: broken hspec shows a multi-KB-per-test slope; fixed
+# hspec shows a slope dominated by the result tree (a few hundred bytes
+# per test). A flat-baseline comparison cancels out the fixed-cost
+# overhead of the test harness itself, which varies by GHC version /
+# runner and otherwise muddies a single-point threshold.
+#
+# Decision basis: GHC.Stats.getRTSStats, read inside the test's
+# afterAll_ hook (where withJobQueue's bracket is still open and the
+# cancel queue, if leaking, is still holding all completed workers) and
+# written to live-bytes.txt. -hT heap profile output is preserved per
+# run for diagnostic visibility but is not the pass/fail signal.
+
+set -o errexit
+cd `dirname "$0"`
+
+N_SMALL=5000
+N_LARGE=50000
+BYTES_PER_TEST_THRESHOLD=1200
+
+ghc -threaded -rtsopts -fforce-recomp Spec.hs
+
+run_size () {
+  local n="$1"
+  local tag="$2"
+  rm -f live-bytes.txt Spec.hp
+  ISSUE961_N="$n" ./Spec -f silent +RTS -hT -T -i0.05 -RTS
+
+  awk -v tag="$tag" -v n="$n" '
+    BEGIN { max_total = -1 }
+    /^BEGIN_SAMPLE/ { time=$2; tso=0; stack=0; async=0; have=0 }
+    /^TSO[[:space:]]/                              { tso=$NF;   have=1 }
+    /^STACK[[:space:]]/                            { stack=$NF; have=1 }
+    /Control\.Concurrent\.Async\.Async[[:space:]]/ { async=$NF; have=1 }
+    /^END_SAMPLE/ {
+      sample_total = tso + stack + async
+      if (sample_total > max_total) {
+        max_total = sample_total
+        max_time = time; max_tso = tso; max_stack = stack; max_async = async
+      }
+      if (have) {
+        last_time = time
+        last_tso = tso; last_stack = stack; last_async = async
+      }
+    }
+    END {
+      printf "issue-961: [%s N=%d] -hT max TSO+STACK+Async = %d at %s (TSO=%d STACK=%d Async=%d)\n", \
+        tag, n, max_total, max_time, max_tso, max_stack, max_async
+      printf "issue-961: [%s N=%d] -hT last sample at %s: total %d (TSO=%d STACK=%d Async=%d)\n", \
+        tag, n, last_time, last_tso + last_stack + last_async, last_tso, last_stack, last_async
+    }
+  ' Spec.hp
+
+  if [ ! -f live-bytes.txt ]; then
+    echo "issue-961: FAIL — live-bytes.txt was not written for $tag run"
+    exit 1
+  fi
+  local live
+  live=$(cat live-bytes.txt)
+  echo "issue-961: [$tag N=$n] GHC.Stats post-GC live bytes = $live"
+  mv live-bytes.txt "live-bytes-$tag.txt"
+  mv Spec.hp "Spec-$tag.hp"
+}
+
+run_size "$N_SMALL" small
+run_size "$N_LARGE" large
+
+LIVE_SMALL=$(cat live-bytes-small.txt)
+LIVE_LARGE=$(cat live-bytes-large.txt)
+
+case "$LIVE_SMALL$LIVE_LARGE" in
+  *[!0-9]*)
+    echo "issue-961: SKIP — GHC.Stats not available on this GHC (small='$LIVE_SMALL' large='$LIVE_LARGE')"
+    rm -f Spec.o Spec.hi Spec Spec-*.hp live-bytes-*.txt
+    exit 0
+    ;;
+esac
+
+DIFF=$((LIVE_LARGE - LIVE_SMALL))
+DN=$((N_LARGE - N_SMALL))
+BYTES_PER_TEST=$((DIFF / DN))
+
+echo "issue-961: live(N=$N_LARGE) - live(N=$N_SMALL) = $DIFF bytes over $DN tests"
+echo "issue-961: slope = $BYTES_PER_TEST bytes/test (threshold $BYTES_PER_TEST_THRESHOLD bytes/test)"
+
+rm -f Spec.o Spec.hi Spec Spec-*.hp live-bytes-*.txt
+
+if [ "$BYTES_PER_TEST" -ge "$BYTES_PER_TEST_THRESHOLD" ]; then
+  echo "issue-961: FAIL — live heap grows $BYTES_PER_TEST bytes per spec item (cancel queue leak)"
+  exit 1
+fi
+
+echo "issue-961: PASS"


### PR DESCRIPTION
The cancel queue (`IORef [Async ()]`) accumulated every spawned job for the duration of a run. Completed asyncs were never removed, so a 50k test run retained ~48 MB of `Async` references plus another ~7 MB of RTS thread bookkeeping that GHC could not reclaim while ThreadIds remained reachable.

Switch to `IORef (Map ThreadId (Async ()))` and have each worker remove its own entry in a `finally`. A small `ready` MVar closes the registration race between `async worker` (which begins running immediately) and the parent's insert. `mask_` around spawn+register preserves the existing exception semantics: an async exception cannot strand a registered-but-ungated worker.

Steady-state cancel queue size is now bounded by concurrency (typically `nproc`) rather than total job count. Measured on a synthetic 50k-spec suite: end-of-run heap drops from ~70 MB to ~14 MB. On my work codebase, this PR results in 64% less memory use on a partial run, and the delta is growing linearly.

Fixes #961 