### PR TITLE
Demonstration: issue-961 regression test alone (no fix)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,8 @@ jobs:
           test/regression/issue-169/run.sh
           cabal install --lib base hspec --package-env test/regression/issue-270/
           test/regression/issue-270/run.sh
+          cabal install --lib base hspec --package-env test/regression/issue-961/
+          test/regression/issue-961/run.sh
         if: "!startsWith(matrix.ghc, '7.') && runner.os != 'Windows'"
 
   success:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,9 @@ jobs:
         run: |
           cabal install --lib base hspec --package-env test/regression/issue-961/
           test/regression/issue-961/run.sh
-        if: "!startsWith(matrix.ghc, '7.') && !startsWith(matrix.ghc, '8.0') && !startsWith(matrix.ghc, '8.2') && !startsWith(matrix.ghc, '8.4') && !startsWith(matrix.ghc, '8.6') && runner.os != 'Windows'"
+        # DEMO PR: skip filter relaxed so every GHC row runs the test and
+        # shows red. Real PR (#962) restricts to GHC 8.8+.
+        if: "!startsWith(matrix.ghc, '7.') && runner.os != 'Windows'"
 
   success:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,9 +94,16 @@ jobs:
           test/regression/issue-169/run.sh
           cabal install --lib base hspec --package-env test/regression/issue-270/
           test/regression/issue-270/run.sh
+        if: "!startsWith(matrix.ghc, '7.') && runner.os != 'Windows'"
+
+      - name: Run issue-961 regression test
+        # On GHC <= 8.6 the RTS retains STACK closures for resumed threads
+        # well past completion, which dominates the heap profile and trips
+        # the threshold even with the fix applied. See test/regression/issue-961/Spec.hs.
+        run: |
           cabal install --lib base hspec --package-env test/regression/issue-961/
           test/regression/issue-961/run.sh
-        if: "!startsWith(matrix.ghc, '7.') && runner.os != 'Windows'"
+        if: "!startsWith(matrix.ghc, '7.') && !startsWith(matrix.ghc, '8.0') && !startsWith(matrix.ghc, '8.2') && !startsWith(matrix.ghc, '8.4') && !startsWith(matrix.ghc, '8.6') && runner.os != 'Windows'"
 
   success:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,14 +99,12 @@ jobs:
         if: "!startsWith(matrix.ghc, '7.') && runner.os != 'Windows'"
 
       - name: Run issue-961 regression test
-        # On GHC <= 8.6 the RTS retains STACK closures for resumed threads
-        # well past completion, which dominates the heap profile and trips
-        # the threshold even with the fix applied. See test/regression/issue-961/Spec.hs.
+        # Slope-based detection (see test/regression/issue-961/run.sh)
+        # is robust across GHC versions. GHC.Stats lives in base-4.10+
+        # (GHC 8.2+); on older GHCs the test self-skips.
         run: |
           cabal install --lib base hspec --package-env test/regression/issue-961/
           test/regression/issue-961/run.sh
-        # DEMO PR: skip filter relaxed so every GHC row runs the test and
-        # shows red. Real PR (#962) restricts to GHC 8.8+.
         if: "!startsWith(matrix.ghc, '7.') && runner.os != 'Windows'"
 
   success:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      # DEMO PR: keep every matrix row running so we can see all the red Xs.
+      fail-fast: false
       matrix:
         os:
           - ubuntu-22.04

--- a/test/regression/issue-961/Spec.hs
+++ b/test/regression/issue-961/Spec.hs
@@ -12,6 +12,15 @@
 -- where a leaked queue is observable. Run with `+RTS -hT -RTS` to produce a
 -- heap profile by closure type; the accompanying run.sh inspects Spec.hp to
 -- validate that worker-state retention stays bounded.
+--
+-- GHC <= 8.6 caveat: the fix adds an MVar-based gate at worker startup so
+-- the parent can register the worker's Async before the worker proceeds.
+-- On GHC <= 8.6 the RTS retains the STACK closures saved for these blocked
+-- threads well past the point where they resume and finish; the heap profile
+-- shows STACK growing into the hundreds of MB across 50k workers regardless
+-- of cancel-queue state. From GHC 8.8 onward STACK closures of resumed
+-- threads are reclaimed promptly and the regression signal is clean. The
+-- workflow therefore only runs this test on GHC 8.8 and later.
 
 module Main (main) where
 

--- a/test/regression/issue-961/Spec.hs
+++ b/test/regression/issue-961/Spec.hs
@@ -6,12 +6,14 @@
 --
 -- Reproducer: a synthetic suite with nested describes (similar shape to a
 -- real test tree) where each leaf does a small amount of work. An
--- `afterAll_` hook performs GC and sleeps for a second, which keeps the
--- cancel queue alive (it lives until `withJobQueue`'s bracket fires) while
--- all worker threads have already completed — that is exactly the window
--- where a leaked queue is observable. Run with `+RTS -hT -RTS` to produce a
--- heap profile by closure type; the accompanying run.sh inspects Spec.hp to
--- validate that worker-state retention stays bounded.
+-- `afterAll_` hook fires after every spec item has finished while
+-- `withJobQueue`'s bracket is still open — that is the window where a
+-- leaked queue is observable. The hook forces a major GC and then reads
+-- live-heap size out of GHC.Stats, writing it to live-bytes.txt for
+-- run.sh to assert against.  Sampling via `+RTS -hT` is kept for
+-- diagnostic output but it turned out to be timing-sensitive across GHC
+-- versions and runner conditions (broken hspec sometimes looked passing
+-- in the last -hT sample), so it is not the decision basis.
 --
 -- GHC <= 8.6 caveat: empirically, on GHC 8.6.5 this benchmark's heap
 -- profile shows STACK retention climbing to ~663 MB across the run when
@@ -27,12 +29,16 @@
 -- still correct on 8.6, but the test doesn't distinguish broken from fixed
 -- there because both retain similar amounts of total state.
 
+{-# LANGUAGE CPP #-}
 module Main (main) where
 
 import           Control.Concurrent (threadDelay)
 import           Control.Monad (forM_)
 import           System.Mem (performGC)
 import           Test.Hspec
+#if MIN_VERSION_base(4,10,0)
+import           GHC.Stats (getRTSStats, getRTSStatsEnabled, gc, gcdetails_live_bytes)
+#endif
 
 outer, middle, leaf :: Int
 outer = 50
@@ -51,10 +57,22 @@ main = hspec $ afterAll_ settle $ describe "issue-961" $
               sum xs `shouldBe` sum xs
 
 -- Runs after every spec item has finished, while withJobQueue's bracket is
--- still open. We force a GC and pause so the heap profiler captures several
--- samples in this state; that's the window where a broken cancel queue is
--- still holding worker references and a fixed one is not.
+-- still open. We force a major GC and then read post-GC live bytes from
+-- GHC.Stats — the cancel queue, if broken, still references ~50k workers
+-- here; if fixed, it is empty. We also pause so the -hT heap profiler can
+-- emit a few samples in this state for human inspection.
 settle :: IO ()
 settle = do
   performGC
+  performGC
+#if MIN_VERSION_base(4,10,0)
+  enabled <- getRTSStatsEnabled
+  if enabled
+    then do
+      stats <- getRTSStats
+      writeFile "live-bytes.txt" (show (gcdetails_live_bytes (gc stats)))
+    else writeFile "live-bytes.txt" "DISABLED"
+#else
+  writeFile "live-bytes.txt" "UNAVAILABLE"
+#endif
   threadDelay 1000000

--- a/test/regression/issue-961/Spec.hs
+++ b/test/regression/issue-961/Spec.hs
@@ -1,0 +1,32 @@
+-- Regression test for hspec#961:
+--   JobQueue.cancelQueue retained one Async (and its underlying TSO) per spec
+--   item for the lifetime of the run, growing O(n) in the number of test
+--   cases. After the fix, completed workers self-deregister, so the queue
+--   only holds in-flight jobs.
+--
+-- Reproducer: a synthetic suite with nested describes (similar shape to a
+-- real test tree) where each leaf does a small amount of work. Run with
+-- `+RTS -hT -RTS` to produce a heap profile by closure type; the
+-- accompanying run.sh inspects Spec.hp to validate that retention of
+-- worker-owned closure types stays roughly constant in the suite size.
+
+module Main (main) where
+
+import           Control.Monad (forM_)
+import           Test.Hspec
+
+outer, middle, leaf :: Int
+outer = 50
+middle = 20
+leaf = 50
+
+main :: IO ()
+main = hspec $ describe "issue-961" $
+  forM_ [1 .. outer] $ \ i ->
+    describe ("group-" <> show i) $
+      forM_ [1 .. middle] $ \ j ->
+        describe ("subgroup-" <> show j) $
+          forM_ [1 .. leaf] $ \ k ->
+            it ("test-" <> show i <> "-" <> show j <> "-" <> show k) $ do
+              let xs = map (\ x -> x * x + i + j + k) [1 .. 200 :: Int]
+              sum xs `shouldBe` sum xs

--- a/test/regression/issue-961/Spec.hs
+++ b/test/regression/issue-961/Spec.hs
@@ -4,63 +4,72 @@
 --   cases. After the fix, completed workers self-deregister, so the queue
 --   only holds in-flight jobs.
 --
--- Reproducer: a synthetic suite with nested describes (similar shape to a
--- real test tree) where each leaf does a small amount of work. An
--- `afterAll_` hook fires after every spec item has finished while
--- `withJobQueue`'s bracket is still open — that is the window where a
--- leaked queue is observable. The hook forces a major GC and then reads
--- live-heap size out of GHC.Stats, writing it to live-bytes.txt for
--- run.sh to assert against.  Sampling via `+RTS -hT` is kept for
--- diagnostic output but it turned out to be timing-sensitive across GHC
--- versions and runner conditions (broken hspec sometimes looked passing
--- in the last -hT sample), so it is not the decision basis.
+-- Detection strategy: run the synthetic suite at two sizes (small and
+-- large), measure post-GC live heap in each run, and assert that the
+-- per-test slope (bytes-per-spec-item, computed across the two sizes) is
+-- small. A leaking queue grows live heap linearly in the spec count, so
+-- the slope is the clean O(n)-vs-O(1) signal we want. A single-point
+-- measurement turns out to be unreliable: it conflates the leak with the
+-- fixed-cost overhead of the test harness itself (result tree, hspec
+-- internal state, base runtime), and the threshold for "broken" depends
+-- on GHC version / runner. Slope cancels that base out.
 --
--- GHC <= 8.6 caveat: empirically, on GHC 8.6.5 this benchmark's heap
--- profile shows STACK retention climbing to ~663 MB across the run when
--- the fix is applied, vs ~45 MB on the same GHC with the unfixed hspec
--- (and ~35 KB on GHC 8.8.4 with the fix). Minimal reproducers with the
--- same worker shape — `forkIO`/`async` + readMVar gate + bracket_ + finally,
--- 50k threads — do *not* show this retention on GHC 8.6.5 (STACK climbs to
--- ~40 MB and drops back to ~8 MB after `performGC`), so this is not a clean
--- "GHC 8.6 fails to reclaim STACK closures" RTS issue.  Something in
--- hspec-core's eval path keeps worker state alive on 8.6.5 in a way it
--- doesn't on 8.8+, and we have not pinned it down. The workflow therefore
--- only runs this regression test on GHC 8.8 and later; the fix itself is
--- still correct on 8.6, but the test doesn't distinguish broken from fixed
--- there because both retain similar amounts of total state.
+-- The suite is built with nested describes (outer/middle/leaf) to roughly
+-- mimic the shape of a real test tree. The leaf count scales with the
+-- chosen size N so the spec count = `outer * middle * leaf` = N exactly.
+-- N is taken from the ISSUE961_N environment variable, with a default
+-- that matches the original 50k-test reproducer.
+--
+-- An `afterAll_` hook fires after every spec item has finished while
+-- `withJobQueue`'s bracket is still open — that is the window where a
+-- leaked queue is observable. The hook forces a major GC, reads
+-- `gcdetails_live_bytes` from `GHC.Stats.getRTSStats`, and writes the
+-- number to `live-bytes.txt` for run.sh to consume. `+RTS -hT` heap
+-- profile output is preserved for diagnostic visibility but is not the
+-- decision basis.
 
 {-# LANGUAGE CPP #-}
 module Main (main) where
 
 import           Control.Concurrent (threadDelay)
 import           Control.Monad (forM_)
+import           Data.Maybe (fromMaybe)
+import           System.Environment (lookupEnv)
 import           System.Mem (performGC)
 import           Test.Hspec
+import           Text.Read (readMaybe)
 #if MIN_VERSION_base(4,10,0)
 import           GHC.Stats (getRTSStats, getRTSStatsEnabled, gc, gcdetails_live_bytes)
 #endif
 
-outer, middle, leaf :: Int
-outer = 50
+-- Fixed describe-tree depth: 50 outer groups, 20 middle subgroups. Leaf
+-- count is derived so that outer * middle * leaf = ISSUE961_N, which
+-- lets run.sh vary N to measure per-spec-item growth.
+outer, middle :: Int
+outer  = 50
 middle = 20
-leaf = 50
+
+defaultN :: Int
+defaultN = 50000
 
 main :: IO ()
-main = hspec $ afterAll_ settle $ describe "issue-961" $
-  forM_ [1 .. outer] $ \ i ->
-    describe ("group-" ++ show i) $
-      forM_ [1 .. middle] $ \ j ->
-        describe ("subgroup-" ++ show j) $
-          forM_ [1 .. leaf] $ \ k ->
-            it ("test-" ++ show i ++ "-" ++ show j ++ "-" ++ show k) $ do
-              let xs = map (\ x -> x * x + i + j + k) [1 .. 200 :: Int]
-              sum xs `shouldBe` sum xs
+main = do
+  n <- fromMaybe defaultN . (>>= readMaybe) <$> lookupEnv "ISSUE961_N"
+  let leaf = max 1 (n `div` (outer * middle))
+  hspec $ afterAll_ settle $ describe "issue-961" $
+    forM_ [1 .. outer] $ \ i ->
+      describe ("group-" ++ show i) $
+        forM_ [1 .. middle] $ \ j ->
+          describe ("subgroup-" ++ show j) $
+            forM_ [1 .. leaf] $ \ k ->
+              it ("test-" ++ show i ++ "-" ++ show j ++ "-" ++ show k) $ do
+                let xs = map (\ x -> x * x + i + j + k) [1 .. 200 :: Int]
+                sum xs `shouldBe` sum xs
 
 -- Runs after every spec item has finished, while withJobQueue's bracket is
 -- still open. We force a major GC and then read post-GC live bytes from
--- GHC.Stats — the cancel queue, if broken, still references ~50k workers
--- here; if fixed, it is empty. We also pause so the -hT heap profiler can
--- emit a few samples in this state for human inspection.
+-- GHC.Stats. The pause keeps the bracket open long enough for -hT to emit
+-- a few diagnostic samples in this state.
 settle :: IO ()
 settle = do
   performGC

--- a/test/regression/issue-961/Spec.hs
+++ b/test/regression/issue-961/Spec.hs
@@ -13,14 +13,19 @@
 -- heap profile by closure type; the accompanying run.sh inspects Spec.hp to
 -- validate that worker-state retention stays bounded.
 --
--- GHC <= 8.6 caveat: the fix adds an MVar-based gate at worker startup so
--- the parent can register the worker's Async before the worker proceeds.
--- On GHC <= 8.6 the RTS retains the STACK closures saved for these blocked
--- threads well past the point where they resume and finish; the heap profile
--- shows STACK growing into the hundreds of MB across 50k workers regardless
--- of cancel-queue state. From GHC 8.8 onward STACK closures of resumed
--- threads are reclaimed promptly and the regression signal is clean. The
--- workflow therefore only runs this test on GHC 8.8 and later.
+-- GHC <= 8.6 caveat: empirically, on GHC 8.6.5 this benchmark's heap
+-- profile shows STACK retention climbing to ~663 MB across the run when
+-- the fix is applied, vs ~45 MB on the same GHC with the unfixed hspec
+-- (and ~35 KB on GHC 8.8.4 with the fix). Minimal reproducers with the
+-- same worker shape — `forkIO`/`async` + readMVar gate + bracket_ + finally,
+-- 50k threads — do *not* show this retention on GHC 8.6.5 (STACK climbs to
+-- ~40 MB and drops back to ~8 MB after `performGC`), so this is not a clean
+-- "GHC 8.6 fails to reclaim STACK closures" RTS issue.  Something in
+-- hspec-core's eval path keeps worker state alive on 8.6.5 in a way it
+-- doesn't on 8.8+, and we have not pinned it down. The workflow therefore
+-- only runs this regression test on GHC 8.8 and later; the fix itself is
+-- still correct on 8.6, but the test doesn't distinguish broken from fixed
+-- there because both retain similar amounts of total state.
 
 module Main (main) where
 

--- a/test/regression/issue-961/Spec.hs
+++ b/test/regression/issue-961/Spec.hs
@@ -5,14 +5,19 @@
 --   only holds in-flight jobs.
 --
 -- Reproducer: a synthetic suite with nested describes (similar shape to a
--- real test tree) where each leaf does a small amount of work. Run with
--- `+RTS -hT -RTS` to produce a heap profile by closure type; the
--- accompanying run.sh inspects Spec.hp to validate that retention of
--- worker-owned closure types stays roughly constant in the suite size.
+-- real test tree) where each leaf does a small amount of work. An
+-- `afterAll_` hook performs GC and sleeps for a second, which keeps the
+-- cancel queue alive (it lives until `withJobQueue`'s bracket fires) while
+-- all worker threads have already completed — that is exactly the window
+-- where a leaked queue is observable. Run with `+RTS -hT -RTS` to produce a
+-- heap profile by closure type; the accompanying run.sh inspects Spec.hp to
+-- validate that worker-state retention stays bounded.
 
 module Main (main) where
 
+import           Control.Concurrent (threadDelay)
 import           Control.Monad (forM_)
+import           System.Mem (performGC)
 import           Test.Hspec
 
 outer, middle, leaf :: Int
@@ -21,7 +26,7 @@ middle = 20
 leaf = 50
 
 main :: IO ()
-main = hspec $ describe "issue-961" $
+main = hspec $ afterAll_ settle $ describe "issue-961" $
   forM_ [1 .. outer] $ \ i ->
     describe ("group-" ++ show i) $
       forM_ [1 .. middle] $ \ j ->
@@ -30,3 +35,12 @@ main = hspec $ describe "issue-961" $
             it ("test-" ++ show i ++ "-" ++ show j ++ "-" ++ show k) $ do
               let xs = map (\ x -> x * x + i + j + k) [1 .. 200 :: Int]
               sum xs `shouldBe` sum xs
+
+-- Runs after every spec item has finished, while withJobQueue's bracket is
+-- still open. We force a GC and pause so the heap profiler captures several
+-- samples in this state; that's the window where a broken cancel queue is
+-- still holding worker references and a fixed one is not.
+settle :: IO ()
+settle = do
+  performGC
+  threadDelay 1000000

--- a/test/regression/issue-961/Spec.hs
+++ b/test/regression/issue-961/Spec.hs
@@ -63,6 +63,10 @@ main = do
           describe ("subgroup-" ++ show j) $
             forM_ [1 .. leaf] $ \ k ->
               it ("test-" ++ show i ++ "-" ++ show j ++ "-" ++ show k) $ do
+                -- Synthetic CPU work so workers spend non-trivial time in
+                -- the action body (and therefore actually concurrently
+                -- occupy the cancel queue). The shouldBe is tautological;
+                -- the leak we measure is per-item, not per-failure.
                 let xs = map (\ x -> x * x + i + j + k) [1 .. 200 :: Int]
                 sum xs `shouldBe` sum xs
 

--- a/test/regression/issue-961/Spec.hs
+++ b/test/regression/issue-961/Spec.hs
@@ -23,10 +23,10 @@ leaf = 50
 main :: IO ()
 main = hspec $ describe "issue-961" $
   forM_ [1 .. outer] $ \ i ->
-    describe ("group-" <> show i) $
+    describe ("group-" ++ show i) $
       forM_ [1 .. middle] $ \ j ->
-        describe ("subgroup-" <> show j) $
+        describe ("subgroup-" ++ show j) $
           forM_ [1 .. leaf] $ \ k ->
-            it ("test-" <> show i <> "-" <> show j <> "-" <> show k) $ do
+            it ("test-" ++ show i ++ "-" ++ show j ++ "-" ++ show k) $ do
               let xs = map (\ x -> x * x + i + j + k) [1 .. 200 :: Int]
               sum xs `shouldBe` sum xs

--- a/test/regression/issue-961/run.sh
+++ b/test/regression/issue-961/run.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Regression test for hspec#961.
+#
+# Runs the synthetic 50k-test suite under `+RTS -hT -RTS` to produce a heap
+# profile by closure type. Then inspects the last non-empty sample (which
+# captures retention right before process exit) and validates that the bytes
+# held in TSO + STACK + Async closures — i.e. the storage the cancel queue
+# would retain per worker — stays roughly constant in the suite size.
+#
+# On the broken JobQueue, ~50k worker TSOs/STACKs are kept alive through the
+# end of the run; STACK alone reaches ~45 MB. With the fix, completed workers
+# self-deregister and the same closures stay under ~5 MB total.
+
+set -o errexit
+cd `dirname "$0"`
+
+THRESHOLD_BYTES=$((15 * 1024 * 1024))
+
+ghc -threaded -rtsopts -fforce-recomp Spec.hs
+./Spec -f silent +RTS -hT -i0.05 -RTS
+
+awk -v threshold="$THRESHOLD_BYTES" '
+  /^BEGIN_SAMPLE/ { time=$2; tso=0; stack=0; async=0; have=0 }
+  /^TSO[[:space:]]/                              { tso=$NF;   have=1 }
+  /^STACK[[:space:]]/                            { stack=$NF; have=1 }
+  /Control\.Concurrent\.Async\.Async[[:space:]]/ { async=$NF; have=1 }
+  /^END_SAMPLE/ {
+    if (have) {
+      last_time = time
+      last_tso = tso
+      last_stack = stack
+      last_async = async
+    }
+  }
+  END {
+    total = last_tso + last_stack + last_async
+    printf "issue-961: last non-empty sample at %s\n", last_time
+    printf "issue-961:   TSO    = %d bytes\n", last_tso
+    printf "issue-961:   STACK  = %d bytes\n", last_stack
+    printf "issue-961:   Async  = %d bytes\n", last_async
+    printf "issue-961:   total  = %d bytes (threshold %d)\n", total, threshold
+    if (total >= threshold) {
+      print "issue-961: FAIL — cancel queue retained completed workers"
+      exit 1
+    }
+    print "issue-961: PASS"
+  }
+' Spec.hp
+
+rm Spec.o Spec.hi Spec Spec.hp

--- a/test/regression/issue-961/run.sh
+++ b/test/regression/issue-961/run.sh
@@ -2,50 +2,80 @@
 #
 # Regression test for hspec#961.
 #
-# Runs the synthetic 50k-test suite under `+RTS -hT -RTS` to produce a heap
-# profile by closure type. Then inspects the last non-empty sample (which
-# captures retention right before process exit) and validates that the bytes
-# held in TSO + STACK + Async closures — i.e. the storage the cancel queue
-# would retain per worker — stays roughly constant in the suite size.
+# Runs the synthetic 50k-test suite and asserts that post-GC live heap
+# during the afterAll_ window stays bounded. The decision is based on
+# GHC.Stats.getRTSStats — read from inside the test, written to
+# live-bytes.txt — because heap profile sampling via -hT turned out to be
+# timing-sensitive across GHC versions / runner conditions (the last -hT
+# sample could land in a moment where the broken cancel queue happened to
+# not dominate the snapshot). getRTSStats after `performGC` gives a
+# deterministic post-GC heap size at the exact window where the bug shows.
 #
 # On the broken JobQueue, ~50k worker TSOs/STACKs are kept alive through the
-# end of the run; STACK alone reaches ~45 MB. With the fix, completed workers
-# self-deregister and the same closures stay under ~5 MB total.
+# afterAll_ hook; live bytes climb well past the threshold. With the fix,
+# completed workers self-deregister and the queue is empty by the time the
+# hook runs.
+#
+# -hT output is still captured and summarised for diagnostic visibility but
+# is not the pass/fail signal.
 
 set -o errexit
 cd `dirname "$0"`
 
-THRESHOLD_BYTES=$((15 * 1024 * 1024))
+LIVE_THRESHOLD_BYTES=$((20 * 1024 * 1024))
 
 ghc -threaded -rtsopts -fforce-recomp Spec.hs
-./Spec -f silent +RTS -hT -i0.05 -RTS
+./Spec -f silent +RTS -hT -T -i0.05 -RTS
 
-awk -v threshold="$THRESHOLD_BYTES" '
+# Diagnostic only: summarise the -hT profile so we can see, in CI logs,
+# what TSO/STACK/Async retention looked like at peak and at exit.
+awk '
+  BEGIN { max_total = -1 }
   /^BEGIN_SAMPLE/ { time=$2; tso=0; stack=0; async=0; have=0 }
   /^TSO[[:space:]]/                              { tso=$NF;   have=1 }
   /^STACK[[:space:]]/                            { stack=$NF; have=1 }
   /Control\.Concurrent\.Async\.Async[[:space:]]/ { async=$NF; have=1 }
   /^END_SAMPLE/ {
+    sample_total = tso + stack + async
+    if (sample_total > max_total) {
+      max_total = sample_total
+      max_time = time; max_tso = tso; max_stack = stack; max_async = async
+    }
     if (have) {
       last_time = time
-      last_tso = tso
-      last_stack = stack
-      last_async = async
+      last_tso = tso; last_stack = stack; last_async = async
     }
   }
   END {
-    total = last_tso + last_stack + last_async
-    printf "issue-961: last non-empty sample at %s\n", last_time
-    printf "issue-961:   TSO    = %d bytes\n", last_tso
-    printf "issue-961:   STACK  = %d bytes\n", last_stack
-    printf "issue-961:   Async  = %d bytes\n", last_async
-    printf "issue-961:   total  = %d bytes (threshold %d)\n", total, threshold
-    if (total >= threshold) {
-      print "issue-961: FAIL — cancel queue retained completed workers"
-      exit 1
-    }
-    print "issue-961: PASS"
+    printf "issue-961: -hT max TSO+STACK+Async  = %d bytes at sample %s (TSO=%d STACK=%d Async=%d)\n", \
+      max_total, max_time, max_tso, max_stack, max_async
+    printf "issue-961: -hT last non-empty sample at %s: total %d bytes (TSO=%d STACK=%d Async=%d)\n", \
+      last_time, last_tso + last_stack + last_async, last_tso, last_stack, last_async
   }
 ' Spec.hp
 
-rm Spec.o Spec.hi Spec Spec.hp
+if [ ! -f live-bytes.txt ]; then
+  echo "issue-961: FAIL — live-bytes.txt was not written (afterAll_ hook did not run?)"
+  rm -f Spec.o Spec.hi Spec Spec.hp
+  exit 1
+fi
+
+LIVE=$(cat live-bytes.txt)
+echo "issue-961: GHC.Stats post-GC live bytes = $LIVE (threshold $LIVE_THRESHOLD_BYTES)"
+
+case "$LIVE" in
+  ''|*[!0-9]*)
+    echo "issue-961: SKIP — GHC.Stats not available on this GHC (value '$LIVE')"
+    rm -f Spec.o Spec.hi Spec Spec.hp live-bytes.txt
+    exit 0
+    ;;
+esac
+
+if [ "$LIVE" -ge "$LIVE_THRESHOLD_BYTES" ]; then
+  echo "issue-961: FAIL — cancel queue retained completed workers"
+  rm -f Spec.o Spec.hi Spec Spec.hp live-bytes.txt
+  exit 1
+fi
+
+echo "issue-961: PASS"
+rm -f Spec.o Spec.hi Spec Spec.hp live-bytes.txt

--- a/test/regression/issue-961/run.sh
+++ b/test/regression/issue-961/run.sh
@@ -2,80 +2,99 @@
 #
 # Regression test for hspec#961.
 #
-# Runs the synthetic 50k-test suite and asserts that post-GC live heap
-# during the afterAll_ window stays bounded. The decision is based on
-# GHC.Stats.getRTSStats — read from inside the test, written to
-# live-bytes.txt — because heap profile sampling via -hT turned out to be
-# timing-sensitive across GHC versions / runner conditions (the last -hT
-# sample could land in a moment where the broken cancel queue happened to
-# not dominate the snapshot). getRTSStats after `performGC` gives a
-# deterministic post-GC heap size at the exact window where the bug shows.
+# Runs the synthetic suite at two spec-count sizes (small ~ N_SMALL and
+# large ~ N_LARGE), measures post-GC live heap in each run, and asserts
+# that bytes-per-spec-item — the slope between the two — is small. A
+# leaking cancel queue retains O(n) per-worker state, so the slope is
+# the clean signal: broken hspec shows a multi-KB-per-test slope; fixed
+# hspec shows a slope dominated by the result tree (a few hundred bytes
+# per test). A flat-baseline comparison cancels out the fixed-cost
+# overhead of the test harness itself, which varies by GHC version /
+# runner and otherwise muddies a single-point threshold.
 #
-# On the broken JobQueue, ~50k worker TSOs/STACKs are kept alive through the
-# afterAll_ hook; live bytes climb well past the threshold. With the fix,
-# completed workers self-deregister and the queue is empty by the time the
-# hook runs.
-#
-# -hT output is still captured and summarised for diagnostic visibility but
-# is not the pass/fail signal.
+# Decision basis: GHC.Stats.getRTSStats, read inside the test's
+# afterAll_ hook (where withJobQueue's bracket is still open and the
+# cancel queue, if leaking, is still holding all completed workers) and
+# written to live-bytes.txt. -hT heap profile output is preserved per
+# run for diagnostic visibility but is not the pass/fail signal.
 
 set -o errexit
 cd `dirname "$0"`
 
-LIVE_THRESHOLD_BYTES=$((20 * 1024 * 1024))
+N_SMALL=5000
+N_LARGE=50000
+BYTES_PER_TEST_THRESHOLD=1500
 
 ghc -threaded -rtsopts -fforce-recomp Spec.hs
-./Spec -f silent +RTS -hT -T -i0.05 -RTS
 
-# Diagnostic only: summarise the -hT profile so we can see, in CI logs,
-# what TSO/STACK/Async retention looked like at peak and at exit.
-awk '
-  BEGIN { max_total = -1 }
-  /^BEGIN_SAMPLE/ { time=$2; tso=0; stack=0; async=0; have=0 }
-  /^TSO[[:space:]]/                              { tso=$NF;   have=1 }
-  /^STACK[[:space:]]/                            { stack=$NF; have=1 }
-  /Control\.Concurrent\.Async\.Async[[:space:]]/ { async=$NF; have=1 }
-  /^END_SAMPLE/ {
-    sample_total = tso + stack + async
-    if (sample_total > max_total) {
-      max_total = sample_total
-      max_time = time; max_tso = tso; max_stack = stack; max_async = async
+run_size () {
+  local n="$1"
+  local tag="$2"
+  rm -f live-bytes.txt Spec.hp
+  ISSUE961_N="$n" ./Spec -f silent +RTS -hT -T -i0.05 -RTS
+
+  awk -v tag="$tag" -v n="$n" '
+    BEGIN { max_total = -1 }
+    /^BEGIN_SAMPLE/ { time=$2; tso=0; stack=0; async=0; have=0 }
+    /^TSO[[:space:]]/                              { tso=$NF;   have=1 }
+    /^STACK[[:space:]]/                            { stack=$NF; have=1 }
+    /Control\.Concurrent\.Async\.Async[[:space:]]/ { async=$NF; have=1 }
+    /^END_SAMPLE/ {
+      sample_total = tso + stack + async
+      if (sample_total > max_total) {
+        max_total = sample_total
+        max_time = time; max_tso = tso; max_stack = stack; max_async = async
+      }
+      if (have) {
+        last_time = time
+        last_tso = tso; last_stack = stack; last_async = async
+      }
     }
-    if (have) {
-      last_time = time
-      last_tso = tso; last_stack = stack; last_async = async
+    END {
+      printf "issue-961: [%s N=%d] -hT max TSO+STACK+Async = %d at %s (TSO=%d STACK=%d Async=%d)\n", \
+        tag, n, max_total, max_time, max_tso, max_stack, max_async
+      printf "issue-961: [%s N=%d] -hT last sample at %s: total %d (TSO=%d STACK=%d Async=%d)\n", \
+        tag, n, last_time, last_tso + last_stack + last_async, last_tso, last_stack, last_async
     }
-  }
-  END {
-    printf "issue-961: -hT max TSO+STACK+Async  = %d bytes at sample %s (TSO=%d STACK=%d Async=%d)\n", \
-      max_total, max_time, max_tso, max_stack, max_async
-    printf "issue-961: -hT last non-empty sample at %s: total %d bytes (TSO=%d STACK=%d Async=%d)\n", \
-      last_time, last_tso + last_stack + last_async, last_tso, last_stack, last_async
-  }
-' Spec.hp
+  ' Spec.hp
 
-if [ ! -f live-bytes.txt ]; then
-  echo "issue-961: FAIL — live-bytes.txt was not written (afterAll_ hook did not run?)"
-  rm -f Spec.o Spec.hi Spec Spec.hp
-  exit 1
-fi
+  if [ ! -f live-bytes.txt ]; then
+    echo "issue-961: FAIL — live-bytes.txt was not written for $tag run"
+    exit 1
+  fi
+  local live
+  live=$(cat live-bytes.txt)
+  echo "issue-961: [$tag N=$n] GHC.Stats post-GC live bytes = $live"
+  mv live-bytes.txt "live-bytes-$tag.txt"
+  mv Spec.hp "Spec-$tag.hp"
+}
 
-LIVE=$(cat live-bytes.txt)
-echo "issue-961: GHC.Stats post-GC live bytes = $LIVE (threshold $LIVE_THRESHOLD_BYTES)"
+run_size "$N_SMALL" small
+run_size "$N_LARGE" large
 
-case "$LIVE" in
-  ''|*[!0-9]*)
-    echo "issue-961: SKIP — GHC.Stats not available on this GHC (value '$LIVE')"
-    rm -f Spec.o Spec.hi Spec Spec.hp live-bytes.txt
+LIVE_SMALL=$(cat live-bytes-small.txt)
+LIVE_LARGE=$(cat live-bytes-large.txt)
+
+case "$LIVE_SMALL$LIVE_LARGE" in
+  *[!0-9]*)
+    echo "issue-961: SKIP — GHC.Stats not available on this GHC (small='$LIVE_SMALL' large='$LIVE_LARGE')"
+    rm -f Spec.o Spec.hi Spec Spec-*.hp live-bytes-*.txt
     exit 0
     ;;
 esac
 
-if [ "$LIVE" -ge "$LIVE_THRESHOLD_BYTES" ]; then
-  echo "issue-961: FAIL — cancel queue retained completed workers"
-  rm -f Spec.o Spec.hi Spec Spec.hp live-bytes.txt
+DIFF=$((LIVE_LARGE - LIVE_SMALL))
+DN=$((N_LARGE - N_SMALL))
+BYTES_PER_TEST=$((DIFF / DN))
+
+echo "issue-961: live(N=$N_LARGE) - live(N=$N_SMALL) = $DIFF bytes over $DN tests"
+echo "issue-961: slope = $BYTES_PER_TEST bytes/test (threshold $BYTES_PER_TEST_THRESHOLD bytes/test)"
+
+rm -f Spec.o Spec.hi Spec Spec-*.hp live-bytes-*.txt
+
+if [ "$BYTES_PER_TEST" -ge "$BYTES_PER_TEST_THRESHOLD" ]; then
+  echo "issue-961: FAIL — live heap grows $BYTES_PER_TEST bytes per spec item (cancel queue leak)"
   exit 1
 fi
 
 echo "issue-961: PASS"
-rm -f Spec.o Spec.hi Spec Spec.hp live-bytes.txt

--- a/test/regression/issue-961/run.sh
+++ b/test/regression/issue-961/run.sh
@@ -23,7 +23,7 @@ cd `dirname "$0"`
 
 N_SMALL=5000
 N_LARGE=50000
-BYTES_PER_TEST_THRESHOLD=1500
+BYTES_PER_TEST_THRESHOLD=1200
 
 ghc -threaded -rtsopts -fforce-recomp Spec.hs
 


### PR DESCRIPTION
**Not for merge.** This PR contains only the issue-961 regression test (from #962) without the JobQueue fix, so we can observe CI behavior against unmodified hspec and confirm the test discriminates the regression.

Expected outcome: the `Run issue-961 regression test` step should fail on every GHC matrix row that runs it (GHC 8.8 through 9.12) — proving the test catches the cancel-queue leak in stock hspec.

Companion to #962, which contains both the fix and this regression test.