### PR TITLE
Strictly limit the number of concurrent threads

### DIFF
--- a/changes/major-972
+++ b/changes/major-972
@@ -1,0 +1,1 @@
+  - Strictly limit the number of concurrent threads (see #972)

--- a/hspec-core/src/Test/Hspec/Core/Runner/Eval.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner/Eval.hs
@@ -38,9 +38,9 @@ import           Data.List.NonEmpty (NonEmpty(..))
 import           Test.Hspec.Core.Runner.JobQueue
 
 data Tree c a =
-    Node String (NonEmpty (Tree c a))
-  | NodeWithCleanup (Maybe (String, Location)) c (NonEmpty (Tree c a))
-  | Leaf a
+    Node !String !(NonEmpty (Tree c a))
+  | NodeWithCleanup !(Maybe (String, Location)) !c !(NonEmpty (Tree c a))
+  | Leaf !a
   deriving (Eq, Show, Functor, Foldable, Traversable)
 
 data EvalConfig = EvalConfig {
@@ -254,10 +254,10 @@ mergeResults mCallSite (Result info r1) r2 = Result info $ case (r1, r2) of
       Just (name, _) -> Just $ "in " ++ name ++ "-hook:"
       Nothing -> Nothing
 
-enqueueItems :: MonadIO m => JobQueue -> [EvalTree] -> IO [RunningTree_ m]
+enqueueItems :: JobQueue (Int, Int) (Seconds, Result) -> [EvalTree] -> IO [RunningTree_ IO]
 enqueueItems queue = mapM (traverse $ enqueueItem queue)
 
-enqueueItem :: MonadIO m => JobQueue -> EvalItem -> IO (RunningItem_ m)
+enqueueItem :: JobQueue (Int, Int) (Seconds, Result) -> EvalItem -> IO (RunningItem_ IO)
 enqueueItem queue EvalItem{..} = do
   job <- enqueueJob queue evalItemConcurrency evalItemAction
   return Item {

--- a/hspec-core/src/Test/Hspec/Core/Runner/JobQueue.hs
+++ b/hspec-core/src/Test/Hspec/Core/Runner/JobQueue.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Test.Hspec.Core.Runner.JobQueue (
   MonadIO
@@ -12,91 +13,71 @@ module Test.Hspec.Core.Runner.JobQueue (
 import           Prelude ()
 import           Test.Hspec.Core.Compat
 
+import           Data.Void (Void)
+
 import           Control.Concurrent
-import           Control.Concurrent.Async (Async, async, waitCatch, cancelMany)
+import           Control.Concurrent.Async (Async, async, cancelMany)
 
 import           Control.Monad.IO.Class
+
+import           Test.Hspec.Core.Util (safeTry)
 
 type Job m progress a = (progress -> m ()) -> m a
 
 data Concurrency = Sequential | Concurrent
 
-data JobQueue = JobQueue {
-  _semaphore :: Semaphore
-, _cancelQueue :: CancelQueue
+newtype JobQueue progress a = JobQueue (Chan (QueuedJob progress a))
+
+data QueuedJob progress a = QueuedJob {
+  action :: Job IO progress a
+, result :: MVar (Result progress a)
 }
 
-data Semaphore = Semaphore {
-  _wait :: IO ()
-, _signal :: IO ()
-}
+data Result progress a = Partial progress | Final (Either SomeException a)
 
-type CancelQueue = IORef [Async ()]
+withJobQueue :: Int -> (JobQueue progress a -> IO r) -> IO r
+withJobQueue concurrency action = do
+  chan <- newChan
+  let
+    worker :: IO Void
+    worker = forever $ readChan chan >>= run
 
-withJobQueue :: Int -> (JobQueue -> IO a) -> IO a
-withJobQueue concurrency = bracket new cancelAll
+    startWorkers :: IO [Async Void]
+    startWorkers = replicateM concurrency $ async worker
+
+  bracket startWorkers cancelMany $ \ _ -> do
+    action $ JobQueue chan
+
+enqueueJob :: JobQueue progress a -> Concurrency -> Job IO progress a -> IO (Job IO progress (Either SomeException a))
+enqueueJob queue = \ case
+  Sequential -> runSequential
+  Concurrent -> runConcurrent queue
+
+runSequential :: Job IO progress a -> IO (Job IO progress (Either SomeException a))
+runSequential action = return $ safeTry . action
+
+runConcurrent :: MonadIO m => JobQueue progress a -> Job IO progress a -> IO (Job m progress (Either SomeException a))
+runConcurrent (JobQueue chan) action = do
+  result <- newEmptyMVar
+  writeChan chan $ QueuedJob action result
+  return $ waitForResult result
+
+run :: forall progress a. QueuedJob progress a -> IO ()
+run QueuedJob {..} = do
+  safeTry (action partialResult) >>= replaceMVar result . Final
   where
-    new :: IO JobQueue
-    new = JobQueue <$> newSemaphore concurrency <*> newIORef []
+    partialResult :: progress -> IO ()
+    partialResult = replaceMVar result . Partial
 
-    cancelAll :: JobQueue -> IO ()
-    cancelAll (JobQueue _ cancelQueue) = readIORef cancelQueue >>= cancelMany
-
-newSemaphore :: Int -> IO Semaphore
-newSemaphore capacity = do
-  sem <- newQSem capacity
-  return $ Semaphore (waitQSem sem) (signalQSem sem)
-
-enqueueJob :: MonadIO m => JobQueue -> Concurrency -> Job IO progress a -> IO (Job m progress (Either SomeException a))
-enqueueJob (JobQueue sem cancelQueue) = \ case
-  Sequential -> runSequential cancelQueue
-  Concurrent -> runConcurrent sem cancelQueue
-
-runSequential :: forall m progress a. MonadIO m => CancelQueue -> Job IO progress a -> IO (Job m progress (Either SomeException a))
-runSequential cancelQueue action = do
-  barrier <- newEmptyMVar
-  let
-    wait :: IO ()
-    wait = takeMVar barrier
-
-    signal :: m ()
-    signal = liftIO $ putMVar barrier ()
-
-  job <- runConcurrent (Semaphore wait pass) cancelQueue action
-  return $ \ notifyPartial -> signal >> job notifyPartial
-
-data Result progress a = Partial progress | Done
-
-runConcurrent :: forall m progress a. MonadIO m => Semaphore -> CancelQueue -> Job IO progress a -> IO (Job m progress (Either SomeException a))
-runConcurrent (Semaphore wait signal) cancelQueue action = do
-  result :: MVar (Result progress a) <- newEmptyMVar
-  let
-    worker :: IO a
-    worker = bracket_ wait signal $ do
-      interruptible (action partialResult) `finally` done
-      where
-        partialResult :: progress -> IO ()
-        partialResult = replaceMVar result . Partial
-
-        done :: IO ()
-        done = replaceMVar result Done
-
-    pushOnCancelQueue :: Async a -> IO ()
-    pushOnCancelQueue = modifyIORef cancelQueue . (:) . void
-
-  job <- bracket (async worker) pushOnCancelQueue return
-
-  return $ waitForResult job result
-
-waitForResult :: forall m progress a. MonadIO m => Async a -> MVar (Result progress a) -> Job m progress (Either SomeException a)
-waitForResult job result notifyPartial = loop
+waitForResult :: forall m progress a. MonadIO m => MVar (Result progress a) -> Job m progress (Either SomeException a)
+waitForResult result notifyPartial = loop
   where
     loop :: m (Either SomeException a)
     loop = do
       r <- liftIO (takeMVar result)
       case r of
         Partial progress -> notifyPartial progress >> loop
-        Done -> liftIO $ waitCatch job
+        Final finalResult -> return finalResult
 
 replaceMVar :: MVar a -> a -> IO ()
 replaceMVar mvar p = tryTakeMVar mvar >> putMVar mvar p


### PR DESCRIPTION
This strictly limits the number of worker threads to the value of `-j` (number of capabilities by default) (we still spawn lots of short lived threads for exception isolation, though).

This cuts memory usage in half with the repro from #972 from 209M down to 117M and brings it closer to the "hello world" baseline of 78M.

```console
$ cabal build --enable-optimization && $(cabal list-bin example) --format progress +RTS -s
…
Finished in 4.0065 seconds
50000 examples, 0 failures
…
             117 MiB total memory in use (0 MiB lost due to fragmentation)
…
```

In general, I think this is a good change.  However, it triggers `test/regression/issue-169` for `GHC < 9.14.1` for some reason.

EDIT:
 - Enabling `-O1` prevents `test/regression/issue-169` for `GHC == 9.*`.
 - Only the `Sequential` code path is affected with `-O0` and `GHC < 9.14.1`.

I think if I put a little bit more time into it, this can be addressed, however I will be traveling, I need to see if/when I get to it.